### PR TITLE
Train models in ensemble for 1.5x longer

### DIFF
--- a/unlimited/train.py
+++ b/unlimited/train.py
@@ -35,7 +35,7 @@ import tiktoken
 
 parser = argparse.ArgumentParser(description="Train GPT ensemble")
 parser.add_argument("--device-batch-size", type=int, default=4)
-parser.add_argument("--num-epochs", type=int, default=12)
+parser.add_argument("--num-epochs", type=int, default=18)
 parser.add_argument("--patience", type=int, default=-1)
 parser.add_argument("--run", type=str, default=None)
 parser.add_argument("--scalar-lr", type=float, default=0.5)


### PR DESCRIPTION
Training for longer (12 -> 18 epochs) reduces performance on individual models: 3.295 -> 3.310.
But it improves the ensemble loss from  3.185-> 3.16639.
Training time: 10h 35m