### PR TITLE
start lr decay early: update warmdown-ratio

### DIFF
--- a/tiny/train.py
+++ b/tiny/train.py
@@ -35,7 +35,7 @@ _script_start = time.time()
 # =============================================================================
 
 parser = argparse.ArgumentParser(description="Train GPT model")
-parser.add_argument("--device-batch-size", type=int, default=32)
+parser.add_argument("--device-batch-size", type=int, default=16)
 parser.add_argument("--num-epochs", type=int, default=16)
 parser.add_argument("--patience", type=int, default=-1)
 parser.add_argument("--run", type=str, default=None)


### PR DESCRIPTION
start lr decay early (warmdown-ratio from 0.5 to 0.6)

Three independent run validation losses:
- 3.38216
- 3.3824
- 3.38229