### PR TITLE
Scheduled weight decay decay for tiny track 

### DIFF
--- a/tiny/train.py
+++ b/tiny/train.py
@@ -827,8 +827,23 @@ while current_epoch <= args.num_epochs:
 
     # Update optimizer
     lrm = get_lr_multiplier(step)
+    # WD schedule: 0.8 for 2ep → decay to 0.1 by ep8 → ramp to 1.25 linearly till end
+    steps_per_epoch = num_iterations // args.num_epochs
+    wd_phase1_end = 2 * steps_per_epoch
+    wd_phase2_end = 8 * steps_per_epoch
+    if step <= wd_phase1_end:
+        wd_scale = 1.0
+    elif step <= wd_phase2_end:
+        progress = (step - wd_phase1_end) / (wd_phase2_end - wd_phase1_end)
+        wd_scale = 1.0 - 0.875 * progress  # 1.0 → 0.125 (0.8→0.1)
+    else:
+        progress = (step - wd_phase2_end) / (num_iterations - wd_phase2_end)
+        wd_scale = 0.125 + (1.5625 - 0.125) * min(progress, 1.0)  # 0.125 → 1.5625 (0.1→1.25)
     for group in optimizer.param_groups:
         group["lr"] = group["initial_lr"] * lrm
+        if "initial_wd" not in group:
+            group["initial_wd"] = group.get("weight_decay", 0.0)
+        group["weight_decay"] = group["initial_wd"] * wd_scale
         if group['kind'] == 'muon':
             group["momentum"] = get_muon_momentum(step)
     optimizer.step()


### PR DESCRIPTION
The the model dramatically overfits at the end (as shown by the increasing difference between train and val loss). To partially rectify this, I set up a weight decay schedule that starts at 0.8 (the old value), decays from epoch 3-8 to 0.1, and then ramps up linearly to 1.25 for the rest of training.  (I  kept weight decay in the beginning following https://arxiv.org/abs/1905.13277. With more com pute it would be useful to see if no weight decay in the beginning would work better, as LM are quite different from other NNs. I also didn't tune the values other than decaying to 0 did not work when I tried it.) The numbers themselves (1.25, 0.1, the last 8 epochs) are pretty much untuned.

Dropout also might be useful to tune at the end here, though that is just a hunch.

Final val loss: 3.366905

Wandb: https://wandb.ai/shmublu/nanochat/runs/kgzsm3l7