### PR TITLE
15' + 1 hour record: Document-level shuffling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ wandb/
 checkpoints/
 logit_avg_ckpts/
 tiny_ckpts/
+runs/

--- a/prepare_data.py
+++ b/prepare_data.py
@@ -15,102 +15,54 @@ import tiktoken
 from datasets import load_dataset
 from tqdm import tqdm
 
-# -----------------------------------------------------------------------------
-# Constants
-
 SEQUENCE_LENGTH = 2048
-SEQUENCE_SIZE = SEQUENCE_LENGTH + 1  # input + target
-BATCH_SIZE = 16  # device batch size, used for chunking
+SEQUENCE_SIZE = SEQUENCE_LENGTH + 1
 
-# Expected SHA-256 hashes
-EXPECTED_HASHES = {
-    "fineweb_val.pt": "80e7e430d3a7d10892c2ff32579370c5b65fbe833579d7ea5d55cbd0504c8462",
-    "fineweb_train.pt": "e7e089aedbccb6865ce76c78453fa473c823969846fccd4000f5f13aef54e70e",
-}
+VAL_SHUFFLE_SEED = 42
+TRAIN_SHUFFLE_SEED = 43
 
-# -----------------------------------------------------------------------------
-# Helpers
 
-def tokenize_documents(dataset_iter, encoder, total_tokens):
-    """Tokenize documents from an iterator until we have total_tokens tokens."""
-    eot = encoder._special_tokens['<|endoftext|>']
+def tokenize_documents(dataset_iter, encoder, token_budget):
+    """Tokenize documents from an iterator, recording document boundaries."""
+    bos_id = encoder._special_tokens["<|endoftext|>"]
     tokens = []
-    pbar = tqdm(total=total_tokens, unit="tok")
+    doc_starts = []
+    pbar = tqdm(total=token_budget, unit="tok")
     for doc in dataset_iter:
-        doc_tokens = [eot] + encoder.encode_ordinary(doc["text"])
-        tokens.extend(doc_tokens)
-        pbar.update(len(doc_tokens))
-        if len(tokens) >= total_tokens:
-            tokens = tokens[:total_tokens]
+        doc_tokens = [bos_id] + encoder.encode_ordinary(doc["text"])
+        doc_starts.append(len(tokens))
+        remaining = token_budget - len(tokens)
+        keep = min(len(doc_tokens), remaining)
+        tokens.extend(doc_tokens[:keep])
+        pbar.update(keep)
+        if len(tokens) >= token_budget:
+            tokens = tokens[:token_budget]
             break
     pbar.close()
-    return tokens
+    return np.asarray(tokens, dtype=np.uint16), np.asarray(doc_starts, dtype=np.int64)
 
 
-def create_sequences(tokens, sequence_size):
-    """Split a flat token list into fixed-size sequences, discarding any remainder."""
-    tokens = np.array(tokens, dtype=np.uint16)
-    num_sequences = len(tokens) // sequence_size
-    tokens = tokens[:num_sequences * sequence_size]
-    sequences = tokens.reshape(num_sequences, sequence_size)
-    return sequences
+def write_datafile(filename, tokens, doc_starts, bos_id, shuffle_seed):
+    if tokens.size == 0:
+        raise ValueError(f"refusing to write empty token stream to {filename}")
+    assert doc_starts[0] == 0
+    assert np.all(tokens[doc_starts] == bos_id)
 
-
-def write_datafile(filename, sequences, batch_size):
-    """
-    Write sequences to a chunked .pt file with padding metadata.
-
-    Format:
-    {
-        'chunks': List[Tensor],       # each chunk is batch_size * sequence_size tokens
-        'valid_counts': List[int],     # real (non-padding) sequences per chunk
-        'batch_size': int,
-        'sequence_size': int,
-    }
-    """
-    if len(sequences) == 0:
-        print(f"Warning: no sequences to write to {filename}")
-        return
-
-    sequence_size = sequences.shape[1]
-    num_sequences = len(sequences)
-    num_full_batches = num_sequences // batch_size
-    leftover = num_sequences % batch_size
-
-    chunks = []
-    valid_counts = []
-
-    # Full batches
-    for i in range(num_full_batches):
-        start = i * batch_size
-        chunk = sequences[start:start + batch_size].reshape(-1)
-        chunks.append(chunk)
-        valid_counts.append(batch_size)
-
-    # Leftover with zero-padding
-    if leftover > 0:
-        leftover_data = sequences[num_full_batches * batch_size:]
-        padding = np.zeros((batch_size - leftover, sequence_size), dtype=np.uint16)
-        padded = np.concatenate([leftover_data, padding], axis=0).reshape(-1)
-        chunks.append(padded)
-        valid_counts.append(leftover)
-
-    print(f"Writing {len(chunks):,} chunks to {filename}")
-    print(f"  {num_sequences:,} sequences ({num_full_batches} full batches of {batch_size})")
-    if leftover > 0:
-        print(f"  Last chunk: {leftover}/{batch_size} valid, {batch_size - leftover} padded")
+    num_seqs = tokens.size // SEQUENCE_SIZE
+    print(f"Writing {filename}")
+    print(f"  {tokens.size:,} tokens, {doc_starts.size:,} docs, {num_seqs:,} sequences")
 
     data = {
-        'chunks': [torch.from_numpy(chunk.copy()) for chunk in chunks],
-        'valid_counts': valid_counts,
-        'batch_size': batch_size,
-        'sequence_size': sequence_size,
+        "tokens": torch.from_numpy(tokens.copy()),
+        "doc_starts": torch.from_numpy(doc_starts.copy()),
+        "bos_id": int(bos_id),
+        "seq_shuffle_seed": int(shuffle_seed),
+        "seq_size": int(SEQUENCE_SIZE),
     }
     torch.save(data, filename)
 
 
 def sha256_file(filepath):
-    """Compute SHA-256 hash of a file."""
     h = hashlib.sha256()
     with open(filepath, "rb") as f:
         for chunk in iter(lambda: f.read(1 << 20), b""):
@@ -118,73 +70,45 @@ def sha256_file(filepath):
     return h.hexdigest()
 
 
-def verify_hash(filepath):
-    """Check file hash against expected value. Print actual hash if mismatch or unset."""
-    basename = os.path.basename(filepath)
-    actual = sha256_file(filepath)
-    expected = EXPECTED_HASHES.get(basename)
-    if expected is None:
-        print(f"  Hash for {basename}: {actual}")
-        print(f"  (no expected hash set — paste this value into EXPECTED_HASHES to lock it in)")
-    elif actual == expected:
-        print(f"  Hash OK for {basename}: {actual}")
-    else:
-        print(f"  HASH MISMATCH for {basename}!")
-        print(f"    expected: {expected}")
-        print(f"    actual:   {actual}")
-
-
-# -----------------------------------------------------------------------------
-# Main
-
 def preprocess(train_tokens, val_tokens, local_dir):
     encoder = tiktoken.get_encoding("gpt2")
-
-    val_seqs = val_tokens // SEQUENCE_SIZE
-    train_seqs = train_tokens // SEQUENCE_SIZE
+    bos_id = encoder._special_tokens["<|endoftext|>"]
 
     print(f"{'='*60}")
     print(f"Preprocessing FineWeb with GPT-2 tokenizer")
     print(f"{'='*60}")
     print(f"Sequence length: {SEQUENCE_LENGTH} (size {SEQUENCE_SIZE})")
-    print(f"Val:   {val_tokens:>13,} raw tokens -> {val_seqs:,} sequences")
-    print(f"Train: {train_tokens:>13,} raw tokens -> {train_seqs:,} sequences")
+    print(f"Val:   {val_tokens:>13,} tokens")
+    print(f"Train: {train_tokens:>13,} tokens")
     print(f"Output: {local_dir}/")
     print(f"{'='*60}")
 
     os.makedirs(local_dir, exist_ok=True)
 
-    # Stream dataset
     dataset = load_dataset("HuggingFaceFW/fineweb", name="sample-10BT", split="train", streaming=True)
     dataset_iter = iter(dataset)
 
-    # Pool 1: val
     print(f"\nTokenizing val ({val_tokens:,} tokens)...")
-    val_raw = tokenize_documents(dataset_iter, encoder, val_tokens)
-    val_sequences = create_sequences(val_raw, SEQUENCE_SIZE)
-    np.random.seed(42)
-    np.random.shuffle(val_sequences)
-    print(f"  {len(val_sequences):,} val sequences ({len(val_sequences) * SEQUENCE_LENGTH:,} trainable tokens)")
+    val_tokens_arr, val_doc_starts = tokenize_documents(dataset_iter, encoder, val_tokens)
+    print(f"  {val_tokens_arr.size:,} tokens, {val_doc_starts.size:,} docs")
 
-    # Pool 2: train (continues from same iterator, no document overlap)
     print(f"\nTokenizing train ({train_tokens:,} tokens)...")
-    train_raw = tokenize_documents(dataset_iter, encoder, train_tokens)
-    train_sequences = create_sequences(train_raw, SEQUENCE_SIZE)
-    np.random.seed(43)
-    np.random.shuffle(train_sequences)
-    print(f"  {len(train_sequences):,} train sequences ({len(train_sequences) * SEQUENCE_LENGTH:,} trainable tokens)")
+    train_tokens_arr, train_doc_starts = tokenize_documents(dataset_iter, encoder, train_tokens)
+    print(f"  {train_tokens_arr.size:,} tokens, {train_doc_starts.size:,} docs")
 
-    # Write
+    # Shut down the streaming dataset before Python finalizes to avoid
+    # background-thread errors (Bad file descriptor / PyGILState_Release).
+    del dataset_iter, dataset
+
     print()
     val_path = os.path.join(local_dir, "fineweb_val.pt")
     train_path = os.path.join(local_dir, "fineweb_train.pt")
-    write_datafile(val_path, val_sequences, BATCH_SIZE)
-    write_datafile(train_path, train_sequences, BATCH_SIZE)
+    write_datafile(val_path, val_tokens_arr, val_doc_starts, bos_id, VAL_SHUFFLE_SEED)
+    write_datafile(train_path, train_tokens_arr, train_doc_starts, bos_id, TRAIN_SHUFFLE_SEED)
 
-    # Verify hashes
     print()
-    verify_hash(val_path)
-    verify_hash(train_path)
+    for p in (val_path, train_path):
+        print(f"  {os.path.basename(p)}: sha256={sha256_file(p)}")
 
     print(f"\nDone! Files saved to {local_dir}/")
 

--- a/prepare_data.py
+++ b/prepare_data.py
@@ -70,6 +70,27 @@ def sha256_file(filepath):
     return h.hexdigest()
 
 
+EXPECTED_HASHES = {
+    "fineweb_val.pt": "6868ed375b289a89c72c2f9df1ecbdcff700c4b9478ca806435d2dbfad8573b1",
+    "fineweb_train.pt": "36e7c95c1e7f6ed952fb002d76a03044e8617fea7e696a68d7dc1ce78465dcaf",
+}
+
+
+def verify_hash(filepath):
+    """Check file hash against expected value and assert it matches."""
+    basename = os.path.basename(filepath)
+    actual = sha256_file(filepath)
+    expected = EXPECTED_HASHES.get(basename)
+    if expected is None:
+        print(f"  Hash for {basename}: {actual}")
+        print(f"  (no expected hash set — paste this value into EXPECTED_HASHES to lock it in)")
+    else:
+        assert actual == expected, (
+            f"HASH MISMATCH for {basename}!\n    expected: {expected}\n    actual:   {actual}"
+        )
+        print(f"  Hash OK for {basename}: {actual}")
+
+
 def preprocess(train_tokens, val_tokens, local_dir):
     encoder = tiktoken.get_encoding("gpt2")
     bos_id = encoder._special_tokens["<|endoftext|>"]
@@ -107,8 +128,8 @@ def preprocess(train_tokens, val_tokens, local_dir):
     write_datafile(train_path, train_tokens_arr, train_doc_starts, bos_id, TRAIN_SHUFFLE_SEED)
 
     print()
-    for p in (val_path, train_path):
-        print(f"  {os.path.basename(p)}: sha256={sha256_file(p)}")
+    verify_hash(val_path)
+    verify_hash(train_path)
 
     print(f"\nDone! Files saved to {local_dir}/")
 

--- a/research/hybrid_attn/train.py
+++ b/research/hybrid_attn/train.py
@@ -18,6 +18,7 @@ import gc
 import math
 import time
 import json
+import numpy as np
 import argparse
 from types import SimpleNamespace
 from functools import partial
@@ -926,22 +927,18 @@ class DistMuonAdamW(torch.optim.Optimizer):
 # =============================================================================
 
 class DataLoader:
-    """Pre-tokenized chunk dataloader. Yields (inputs, targets, epoch) forever."""
+    """Pre-tokenized dataloader. Yields (inputs, targets, epoch) forever."""
 
     def __init__(self, filepath, B, T, device="cuda"):
         data = torch.load(filepath, weights_only=True)
-        chunks = data['chunks']
-        valid_counts = data['valid_counts']
-        file_B = data['batch_size']
-        sequence_size = data['sequence_size']
-        assert sequence_size == T + 1, f"Data sequence_size {sequence_size} != T+1={T+1}"
+        all_tokens = data["tokens"].long()
+        sequence_size = T + 1
 
-        # Gather all valid sequences into one tensor
-        all_seqs = []
-        for chunk, vc in zip(chunks, valid_counts):
-            rows = chunk.view(file_B, sequence_size)[:vc]
-            all_seqs.append(rows)
-        all_seqs = torch.cat(all_seqs, dim=0).long()  # (N, T+1)
+        # Reconstruct the old sequence ordering from flat tokens
+        num_seqs = len(all_tokens) // sequence_size
+        all_seqs = all_tokens[:num_seqs * sequence_size].view(num_seqs, sequence_size)
+        perm = np.random.RandomState(data["seq_shuffle_seed"]).permutation(num_seqs)
+        all_seqs = all_seqs[torch.from_numpy(perm)]  # (N, T+1)
 
         # DDP sharding: each rank gets every world_size-th batch
         _, rank, _, world_size = get_dist_info()

--- a/research/universal_transformer/train.py
+++ b/research/universal_transformer/train.py
@@ -12,6 +12,7 @@ import gc
 import math
 import time
 import json
+import numpy as np
 import argparse
 from types import SimpleNamespace
 from functools import partial
@@ -774,22 +775,18 @@ class DistMuonAdamW(torch.optim.Optimizer):
 # =============================================================================
 
 class DataLoader:
-    """Pre-tokenized chunk dataloader. Yields (inputs, targets, epoch) forever."""
+    """Pre-tokenized dataloader. Yields (inputs, targets, epoch) forever."""
 
     def __init__(self, filepath, B, T, device="cuda"):
         data = torch.load(filepath, weights_only=True)
-        chunks = data['chunks']
-        valid_counts = data['valid_counts']
-        file_B = data['batch_size']
-        sequence_size = data['sequence_size']
-        assert sequence_size == T + 1, f"Data sequence_size {sequence_size} != T+1={T+1}"
+        all_tokens = data["tokens"].long()
+        sequence_size = T + 1
 
-        # Gather all valid sequences into one tensor
-        all_seqs = []
-        for chunk, vc in zip(chunks, valid_counts):
-            rows = chunk.view(file_B, sequence_size)[:vc]
-            all_seqs.append(rows)
-        all_seqs = torch.cat(all_seqs, dim=0).long()  # (N, T+1)
+        # Reconstruct the old sequence ordering from flat tokens
+        num_seqs = len(all_tokens) // sequence_size
+        all_seqs = all_tokens[:num_seqs * sequence_size].view(num_seqs, sequence_size)
+        perm = np.random.RandomState(data["seq_shuffle_seed"]).permutation(num_seqs)
+        all_seqs = all_seqs[torch.from_numpy(perm)]  # (N, T+1)
 
         # DDP sharding: each rank gets every world_size-th batch
         _, rank, _, world_size = get_dist_info()

--- a/tiny/train.py
+++ b/tiny/train.py
@@ -15,9 +15,7 @@ import time
 import json
 import argparse
 import sys
-import secrets
 import shutil
-import string
 from types import SimpleNamespace
 from functools import partial
 from dataclasses import dataclass
@@ -155,8 +153,7 @@ def resolve_run_dir(run_name):
     if run_name:
         actual_run_name = run_name
     else:
-        alphabet = string.ascii_lowercase + string.digits
-        actual_run_name = "".join(secrets.choice(alphabet) for _ in range(6))
+        actual_run_name = time.strftime('%Y%m%d_%H%M%S')
     return actual_run_name, os.path.join(RUNS_DIR, actual_run_name)
 
 # =============================================================================

--- a/tiny/train.py
+++ b/tiny/train.py
@@ -14,6 +14,10 @@ import math
 import time
 import json
 import argparse
+import sys
+import secrets
+import shutil
+import string
 from types import SimpleNamespace
 from functools import partial
 from dataclasses import dataclass
@@ -39,7 +43,8 @@ parser = argparse.ArgumentParser(description="Train GPT model")
 parser.add_argument("--device-batch-size", type=int, default=32)
 parser.add_argument("--num-epochs", type=int, default=16)
 parser.add_argument("--patience", type=int, default=-1)
-parser.add_argument("--run", type=str, default=None)
+parser.add_argument("--run-name", type=str, default=None,
+                    help="Run name under runs/ (default: random 6-char string)")
 parser.add_argument("--scalar-lr", type=float, default=0.25)
 parser.add_argument("--matrix-lr", type=float, default=0.04)
 parser.add_argument("--embedding-lr", type=float, default=0.15)
@@ -69,6 +74,8 @@ parser.add_argument("--update-ema-every", type=int, default=10)
 parser.add_argument("--ema-decay-per-epoch", type=float, default=0.15)
 parser.add_argument("--swa-last-epochs", type=int, default=4,
                     help="SWA: cosine-cycle LR in last N epochs for checkpoint diversity (0=off)")
+parser.add_argument("--no-doc-shuffle", action="store_true",
+                    help="Disable per-epoch document reshuffling (still shuffles batch order)")
 args = parser.parse_args()
 
 # Resolve output path
@@ -89,6 +96,8 @@ WINDOW_PATTERN = "SSSL"
 TOTAL_BATCH_SIZE = args.total_batch_size
 EVAL_TOKENS = 10_000_000
 DATA_DIR = "fineweb_data"
+BOS_ID = 50256  # <|endoftext|>
+RUNS_DIR = "runs"
 
 # Base optimizer hyperparameters
 BASE_MATRIX_LR = args.matrix_lr
@@ -126,6 +135,29 @@ class DummyWandb:
     def __init__(self): self.summary = {}
     def log(self, *a, **kw): pass
     def finish(self): pass
+
+class TeeStream:
+    """Save terminal output to file."""
+    def __init__(self, *streams):
+        self.streams = streams
+        self.encoding = getattr(streams[0], "encoding", "utf-8")
+    def write(self, data):
+        for stream in self.streams: stream.write(data)
+        return len(data)
+    def flush(self):
+        for stream in self.streams: stream.flush()
+    def isatty(self):
+        return any(getattr(stream, "isatty", lambda: False)() for stream in self.streams)
+    def fileno(self):
+        return self.streams[0].fileno()
+
+def resolve_run_dir(run_name):
+    if run_name:
+        actual_run_name = run_name
+    else:
+        alphabet = string.ascii_lowercase + string.digits
+        actual_run_name = "".join(secrets.choice(alphabet) for _ in range(6))
+    return actual_run_name, os.path.join(RUNS_DIR, actual_run_name)
 
 # =============================================================================
 # Flash Attention (FA3 on Hopper, SDPA fallback elsewhere)
@@ -189,6 +221,7 @@ class GPTConfig:
     n_embd: int = N_EMBD
     window_pattern: str = WINDOW_PATTERN
     dropout: float = 0.1
+    device_batch_size: int = 32
 
 def norm(x):
     return F.rms_norm(x, (x.size(-1),))
@@ -606,53 +639,76 @@ class DistMuonAdamW(torch.optim.Optimizer):
 # =============================================================================
 
 class DataLoader:
-    """Pre-tokenized chunk dataloader. Yields (inputs, targets, epoch) forever."""
+    """Loads flat tokens + chunks into batches.
 
-    def __init__(self, filepath, B, T, device="cuda"):
+    doc_shuffle=False: applies the stored default sequence permutation (bitwise match
+    with the old chunked pipeline), shuffles batch order each epoch.
+    doc_shuffle=True: reshuffles documents each epoch, re-chunks, re-shuffles sequences.
+    """
+
+    def __init__(self, filepath, B, T, device="cuda", *, doc_shuffle=False):
         data = torch.load(filepath, weights_only=True)
-        chunks = data['chunks']
-        valid_counts = data['valid_counts']
-        file_B = data['batch_size']
-        sequence_size = data['sequence_size']
-        assert sequence_size == T + 1, f"Data sequence_size {sequence_size} != T+1={T+1}"
+        all_tokens = data["tokens"].long()
+        raw_doc_starts = data["doc_starts"].long()
+        bos_id = int(data["bos_id"])
+        assert bos_id == BOS_ID, f"data bos_id {bos_id} != expected {BOS_ID}"
 
-        # Gather all valid sequences into one tensor
-        all_seqs = []
-        for chunk, vc in zip(chunks, valid_counts):
-            rows = chunk.view(file_B, sequence_size)[:vc]
-            all_seqs.append(rows)
-        all_seqs = torch.cat(all_seqs, dim=0).long()  # (N, T+1)
+        doc_ends = torch.cat([raw_doc_starts[1:], torch.tensor([all_tokens.numel()])])
+        self.doc_tokens = [all_tokens[s:e] for s, e in zip(raw_doc_starts.tolist(), doc_ends.tolist())]
+        self.default_shuffle_seed = data["seq_shuffle_seed"]
 
-        # DDP sharding: each rank gets every world_size-th batch
         _, rank, _, world_size = get_dist_info()
-        seqs_per_step = B * world_size
+        self.rank = rank
+        self.world_size = world_size
+        self.device = device
+        self.B = B
+        self.T = T
+        self.seq_size = T + 1
+        self.doc_shuffle = doc_shuffle
+        self.epoch = 1
+        self._build_batches()
+
+    def _build_batches(self):
+        tokens = torch.cat(self.doc_tokens)
+        num_seqs = len(tokens) // self.seq_size
+        all_seqs = tokens[:num_seqs * self.seq_size].view(num_seqs, self.seq_size)
+        if self.doc_shuffle:
+            g = torch.Generator()
+            g.manual_seed(self.epoch + 1000)
+            all_seqs = all_seqs[torch.randperm(num_seqs, generator=g)]
+        else:   # Use dataset-stored permutation seed for backwards compatibility.
+            perm = np.random.RandomState(self.default_shuffle_seed).permutation(num_seqs)
+            all_seqs = all_seqs[torch.from_numpy(perm)]
+        seqs_per_step = self.B * self.world_size
         num_steps = len(all_seqs) // seqs_per_step
         usable = num_steps * seqs_per_step
-        all_seqs = all_seqs[:usable].view(num_steps, world_size, B, sequence_size)
-
-        self.rank_data = all_seqs[:, rank].contiguous()  # (num_steps, B, T+1)
+        all_seqs = all_seqs[:usable].view(num_steps, self.world_size, self.B, self.seq_size)
+        self.rank_data = all_seqs[:, self.rank].contiguous()
         self.num_steps = num_steps
-        self.total_tokens = usable * T  # trainable tokens across all ranks
-        self.device = device
+        self.total_tokens = usable * self.T
         self.pos = 0
-        self.epoch = 1
 
     def __iter__(self):
         return self
 
-    def _shuffle(self):
-        """Shuffle batch order for the new epoch, consistent across ranks."""
-        g = torch.Generator()
-        g.manual_seed(self.epoch)
-        perm = torch.randperm(self.num_steps, generator=g)
-        self.rank_data = self.rank_data[perm]
+    def _next_epoch(self):
+        self.epoch += 1
+        print0(f"Starting epoch {self.epoch}")
+        if self.doc_shuffle:
+            g = torch.Generator()
+            g.manual_seed(self.epoch)
+            perm = torch.randperm(len(self.doc_tokens), generator=g)
+            self.doc_tokens = [self.doc_tokens[i] for i in perm.tolist()]
+            self._build_batches()
+        else:
+            self.pos = 0
+            g = torch.Generator()
+            g.manual_seed(self.epoch)
+            self.rank_data = self.rank_data[torch.randperm(self.num_steps, generator=g)]
 
     def __next__(self):
         if self.pos >= self.num_steps:
-            self.pos = 0
-            self.epoch += 1
-            print0(f"Starting epoch {self.epoch}")
-            self._shuffle()
+            self._next_epoch()
         batch = self.rank_data[self.pos].to(self.device, non_blocking=True)
         self.pos += 1
         return batch[:, :-1].contiguous(), batch[:, 1:].contiguous(), self.epoch
@@ -727,11 +783,36 @@ if _fa3 is not None:
 else:
     print0("Using PyTorch SDPA fallback (no FA3)")
 
+# Run / logging paths
+run_name, run_dir = resolve_run_dir(args.run_name)
+if dist.is_initialized():
+    shared = [run_name]
+    dist.broadcast_object_list(shared, src=0)
+    run_name = shared[0]
+    run_dir = os.path.join(RUNS_DIR, run_name)
+checkpoints_dir = os.path.join(run_dir, "checkpoints")
+artifact_model_path = os.path.join(run_dir, "model.pt")
+terminal_log_path = os.path.join(run_dir, "terminal.log")
+stdout_orig = sys.stdout
+stderr_orig = sys.stderr
+artifacts_log_f = None
+result_path = os.path.join(run_dir, "result.json")
+os.makedirs(run_dir, exist_ok=True)
+if master_process:
+    os.makedirs(checkpoints_dir, exist_ok=True)
+    os.makedirs(os.path.join(run_dir, "wandb"), exist_ok=True)
+    shutil.copy2(__file__, os.path.join(run_dir, "train.py"))
+if dist.is_initialized():
+    dist.barrier()
+artifacts_log_f = open(terminal_log_path, "a", encoding="utf-8", buffering=1)
+sys.stdout = TeeStream(sys.stdout, artifacts_log_f)
+sys.stderr = TeeStream(sys.stderr, artifacts_log_f)
+
 # wandb
-run_name = args.run if args.run else time.strftime("%Y%m%d_%H%M%S")
 _wandb_kwargs = {"project": "slowrun", "name": run_name}
 if args.wandb_group:
     _wandb_kwargs["group"] = args.wandb_group
+_wandb_kwargs["dir"] = os.path.join(run_dir, "wandb")
 wandb_run = DummyWandb() if not master_process else wandb.init(**_wandb_kwargs)
 if master_process:
     wandb_run.log_code(".")
@@ -746,6 +827,9 @@ print0(f"  weight_decay={WEIGHT_DECAY}, adam_betas={ADAM_BETAS}")
 print0(f"  warmup_ratio={WARMUP_RATIO}, warmdown_ratio={WARMDOWN_RATIO}, final_lr_frac={FINAL_LR_FRAC}")
 print0(f"  num_epochs={args.num_epochs}, patience={args.patience}")
 print0(f"  dropout={args.dropout}")
+print0(f"  doc_shuffle={not args.no_doc_shuffle}")
+print0(f"  run={run_name}")
+print0(f"  run_dir={run_dir}")
 print0(f"-----------------------")
 
 # Load GPT-2 tokenizer and compute token_bytes for BPB evaluation
@@ -763,7 +847,7 @@ for i in range(vocab_size):
 token_bytes = torch.tensor(token_bytes_list, dtype=torch.int32, device=device)
 
 # Build model
-config = GPTConfig(vocab_size=vocab_size, dropout=args.dropout)
+config = GPTConfig(vocab_size=vocab_size, dropout=args.dropout, device_batch_size=args.device_batch_size)
 with torch.device("meta"):
     model = GPT(config)
 model.to_empty(device=device)
@@ -788,7 +872,7 @@ optimizer = model.setup_optimizer()
 # Dataloaders
 _train_path = args.input_bin if args.input_bin else os.path.join(DATA_DIR, "fineweb_train.pt")
 _val_path = args.input_val_bin if args.input_val_bin else os.path.join(DATA_DIR, "fineweb_val.pt")
-train_loader = DataLoader(_train_path, args.device_batch_size, MAX_SEQ_LEN, device=device)
+train_loader = DataLoader(_train_path, args.device_batch_size, MAX_SEQ_LEN, device=device, doc_shuffle=not args.no_doc_shuffle)
 build_val_loader = lambda: DataLoader(_val_path, args.device_batch_size, MAX_SEQ_LEN, device=device)
 TOKENS_PER_EPOCH = train_loader.total_tokens
 x, y, current_epoch = next(train_loader)
@@ -919,9 +1003,8 @@ while current_epoch <= args.num_epochs:
         print0(f"Step {step:05d} | Epoch {current_epoch} | Val BPB: {val_bpb:.6f} | Val Loss: {val_loss:.6f}")
         wandb_run.log({"step": step, "epoch": current_epoch, "val/bpb": val_bpb, "val/loss": val_loss})
         # Save checkpoint for weight averaging
-        ckpt_path = os.path.join("tiny_ckpts", f"epoch_{current_epoch:03d}.pt")
+        ckpt_path = os.path.join(checkpoints_dir, f"epoch_{current_epoch:03d}.pt")
         if master_process:
-            os.makedirs("tiny_ckpts", exist_ok=True)
             torch.save({n: p.data.float().cpu() for n, p in orig_model.named_parameters()}, ckpt_path)
         late_ckpt_paths.append(ckpt_path)
         if len(late_ckpt_paths) > args.swa_last_epochs:
@@ -1001,7 +1084,7 @@ print0(f"Min val Loss: {min_val_loss:.6f}")
 wandb_run.summary["final_train_loss"] = final_train_loss
 wandb_run.summary["best_val_loss"] = min_val_loss
 
-if args.save_result and master_process:
+if master_process:
     result = {
         "matrix_lr": args.matrix_lr,
         "weight_decay": args.weight_decay,
@@ -1010,13 +1093,25 @@ if args.save_result and master_process:
         "best_val_loss": min_val_loss,
         "wandb_url": getattr(wandb_run, "url", None),
     }
-    with open(args.save_result, "w") as f:
+    with open(result_path, "w") as f:
         json.dump(result, f, indent=2)
-    print0(f"Result saved to {args.save_result}")
+    print0(f"Result saved to {result_path}")
 
+# Save final model
+if master_process:
+    print0(f"Saving model to {artifact_model_path}")
+    torch.save({n: p.data.float().cpu() for n, p in orig_model.named_parameters()}, artifact_model_path)
+
+print0(f"Min val BPB: {min_val_bpb:.6f} | Min val Loss: {min_val_loss:.6f}")
 total_wall_time = time.time() - _script_start
 print0(f"Total wall time: {total_wall_time:.2f}s ({total_wall_time/60:.2f}m)")
 
 wandb_run.finish()
 if dist.is_initialized():
     dist.destroy_process_group()
+if artifacts_log_f is not None:
+    sys.stdout.flush()
+    sys.stderr.flush()
+    sys.stdout = stdout_orig
+    sys.stderr = stderr_orig
+    artifacts_log_f.close()

--- a/train.py
+++ b/train.py
@@ -14,8 +14,6 @@ import time
 import json
 import sys
 import shutil
-import string
-import secrets
 import argparse
 from types import SimpleNamespace
 from functools import partial
@@ -173,7 +171,7 @@ class TeeStream:
 def resolve_run_dir(run_name):
     if run_name:
         return run_name, os.path.join(RUNS_DIR, run_name)
-    name = "".join(secrets.choice(string.ascii_lowercase + string.digits) for _ in range(6))
+    name = time.strftime('%Y%m%d_%H%M%S')
     return name, os.path.join(RUNS_DIR, name)
 
 # =============================================================================

--- a/train.py
+++ b/train.py
@@ -12,12 +12,17 @@ import gc
 import math
 import time
 import json
+import sys
+import shutil
+import string
+import secrets
 import argparse
 from types import SimpleNamespace
 from functools import partial
 from dataclasses import dataclass
 from contextlib import nullcontext
 
+import numpy as np
 import torch
 import torch._dynamo
 torch._dynamo.config.cache_size_limit = 64
@@ -38,7 +43,8 @@ parser = argparse.ArgumentParser(description="Train GPT model")
 parser.add_argument("--device-batch-size", type=int, default=4)
 parser.add_argument("--num-epochs", type=int, default=11)
 parser.add_argument("--patience", type=int, default=-1)
-parser.add_argument("--run", type=str, default=None)
+parser.add_argument("--run-name", type=str, default=None,
+                    help="Run name under runs/ (default: random 6-char string)")
 parser.add_argument("--scalar-lr", type=float, default=0.1)
 parser.add_argument("--matrix-lr", type=float, default=0.04)
 parser.add_argument("--weight-decay", type=float, default=1.3)
@@ -86,6 +92,8 @@ parser.add_argument("--no-iha", action="store_false", dest="iha",
                     help="Disable IHA cross-head mixing")
 parser.add_argument("--iha-lr", type=float, default=0.02,
                     help="LR for IHA mixing matrices")
+parser.add_argument("--no-doc-shuffle", action="store_true",
+                    help="Disable per-epoch document reshuffling (still shuffles batch order)")
 args = parser.parse_args()
 
 # Resolve output path
@@ -106,6 +114,8 @@ WINDOW_PATTERN = "SSSL"
 TOTAL_BATCH_SIZE = args.total_batch_size
 EVAL_TOKENS = 10_000_000
 DATA_DIR = "fineweb_data"
+BOS_ID = 50256  # <|endoftext|>
+RUNS_DIR = "runs"
 
 # Base optimizer hyperparameters
 BASE_MATRIX_LR = args.matrix_lr
@@ -144,6 +154,27 @@ class DummyWandb:
     def __init__(self): self.summary = {}
     def log(self, *a, **kw): pass
     def finish(self): pass
+
+class TeeStream:
+    """Save terminal output to file."""
+    def __init__(self, *streams):
+        self.streams = streams
+        self.encoding = getattr(streams[0], "encoding", "utf-8")
+    def write(self, data):
+        for stream in self.streams: stream.write(data)
+        return len(data)
+    def flush(self):
+        for stream in self.streams: stream.flush()
+    def isatty(self):
+        return any(getattr(stream, "isatty", lambda: False)() for stream in self.streams)
+    def fileno(self):
+        return self.streams[0].fileno()
+
+def resolve_run_dir(run_name):
+    if run_name:
+        return run_name, os.path.join(RUNS_DIR, run_name)
+    name = "".join(secrets.choice(string.ascii_lowercase + string.digits) for _ in range(6))
+    return name, os.path.join(RUNS_DIR, name)
 
 # =============================================================================
 def load_state_dict_into_model(model, state_dict):
@@ -726,53 +757,78 @@ class DistMuonAdamW(torch.optim.Optimizer):
 # =============================================================================
 
 class DataLoader:
-    """Pre-tokenized chunk dataloader. Yields (inputs, targets, epoch) forever."""
+    """Loads flat tokens , chunks into batches.
 
-    def __init__(self, filepath, B, T, device="cuda"):
+    doc_shuffle=False: applies the stored default sequence permutation (bitwise match
+    with the old chunked pipeline), shuffles batch order each epoch.
+    doc_shuffle=True: reshuffles documents each epoch, re-chunks, re-shuffles sequences.
+
+    Always yields (x, y, epoch).
+    """
+
+    def __init__(self, filepath, B, T, device="cuda", doc_shuffle=False):
         data = torch.load(filepath, weights_only=True)
-        chunks = data['chunks']
-        valid_counts = data['valid_counts']
-        file_B = data['batch_size']
-        sequence_size = data['sequence_size']
-        assert sequence_size == T + 1, f"Data sequence_size {sequence_size} != T+1={T+1}"
+        all_tokens = data["tokens"].long()
+        raw_doc_starts = data["doc_starts"].long()
+        bos_id = int(data["bos_id"])
+        assert bos_id == BOS_ID, f"data bos_id {bos_id} != expected {BOS_ID}"
 
-        # Gather all valid sequences into one tensor
-        all_seqs = []
-        for chunk, vc in zip(chunks, valid_counts):
-            rows = chunk.view(file_B, sequence_size)[:vc]
-            all_seqs.append(rows)
-        all_seqs = torch.cat(all_seqs, dim=0).long()  # (N, T+1)
+        doc_ends = torch.cat([raw_doc_starts[1:], torch.tensor([all_tokens.numel()])])
+        self.doc_tokens = [all_tokens[s:e] for s, e in zip(raw_doc_starts.tolist(), doc_ends.tolist())]
+        self.default_shuffle_seed = data["seq_shuffle_seed"]
 
-        # DDP sharding: each rank gets every world_size-th batch
         _, rank, _, world_size = get_dist_info()
-        seqs_per_step = B * world_size
+        self.rank = rank
+        self.world_size = world_size
+        self.device = device
+        self.B = B
+        self.T = T
+        self.seq_size = T + 1
+        self.doc_shuffle = doc_shuffle
+        self.epoch = 1
+        self._build_batches()
+
+    def _build_batches(self):
+        tokens = torch.cat(self.doc_tokens)
+        num_seqs = len(tokens) // self.seq_size
+        all_seqs = tokens[:num_seqs * self.seq_size].view(num_seqs, self.seq_size)
+        if self.doc_shuffle:
+            g = torch.Generator()
+            g.manual_seed(self.epoch + 1000)
+            all_seqs = all_seqs[torch.randperm(num_seqs, generator=g)]
+        else:
+            perm = np.random.RandomState(self.default_shuffle_seed).permutation(num_seqs)
+            all_seqs = all_seqs[torch.from_numpy(perm)]
+        seqs_per_step = self.B * self.world_size
         num_steps = len(all_seqs) // seqs_per_step
         usable = num_steps * seqs_per_step
-        all_seqs = all_seqs[:usable].view(num_steps, world_size, B, sequence_size)
-
-        self.rank_data = all_seqs[:, rank].contiguous()  # (num_steps, B, T+1)
+        all_seqs = all_seqs[:usable].view(num_steps, self.world_size, self.B, self.seq_size)
+        self.rank_data = all_seqs[:, self.rank].contiguous()
         self.num_steps = num_steps
-        self.total_tokens = usable * T  # trainable tokens across all ranks
-        self.device = device
+        self.total_tokens = usable * self.T
         self.pos = 0
-        self.epoch = 1
 
     def __iter__(self):
         return self
 
-    def _shuffle(self):
-        """Shuffle batch order for the new epoch, consistent across ranks."""
-        g = torch.Generator()
-        g.manual_seed(self.epoch)
-        perm = torch.randperm(self.num_steps, generator=g)
-        self.rank_data = self.rank_data[perm]
+    def _next_epoch(self):
+        self.epoch += 1
+        print0(f"Starting epoch {self.epoch}")
+        if self.doc_shuffle:
+            g = torch.Generator()
+            g.manual_seed(self.epoch)
+            perm = torch.randperm(len(self.doc_tokens), generator=g)
+            self.doc_tokens = [self.doc_tokens[i] for i in perm.tolist()]
+            self._build_batches()
+        else:
+            self.pos = 0
+            g = torch.Generator()
+            g.manual_seed(self.epoch)
+            self.rank_data = self.rank_data[torch.randperm(self.num_steps, generator=g)]
 
     def __next__(self):
         if self.pos >= self.num_steps:
-            self.pos = 0
-            self.epoch += 1
-            print0(f"Starting epoch {self.epoch}")
-            self._shuffle()
+            self._next_epoch()
         batch = self.rank_data[self.pos].to(self.device, non_blocking=True)
         self.pos += 1
         return batch[:, :-1].contiguous(), batch[:, 1:].contiguous(), self.epoch
@@ -915,9 +971,29 @@ if _fa3 is not None:
 else:
     raise RuntimeError("Flash Attention 3 is required but not available. A Hopper (sm90) GPU is needed.")
 
+# Run / logging paths
+run_name, run_dir = resolve_run_dir(args.run_name)
+if dist.is_initialized():
+    shared = [run_name]
+    dist.broadcast_object_list(shared, src=0)
+    run_name = shared[0]
+    run_dir = os.path.join(RUNS_DIR, run_name)
+checkpoints_dir = os.path.join(run_dir, "checkpoints")
+terminal_log_path = os.path.join(run_dir, "terminal.log")
+stdout_orig = sys.stdout
+stderr_orig = sys.stderr
+artifacts_log_f = None
+result_path = os.path.join(run_dir, "result.json")
+if master_process:
+    os.makedirs(checkpoints_dir, exist_ok=True)
+    os.makedirs(os.path.join(run_dir, "wandb"), exist_ok=True)
+    shutil.copy2(__file__, os.path.join(run_dir, "train.py"))
+    artifacts_log_f = open(terminal_log_path, "a", encoding="utf-8", buffering=1)
+    sys.stdout = TeeStream(sys.stdout, artifacts_log_f)
+    sys.stderr = TeeStream(sys.stderr, artifacts_log_f)
+
 # wandb
-run_name = args.run if args.run else time.strftime("%Y%m%d_%H%M%S")
-_wandb_kwargs = {"project": "slowrun", "name": run_name}
+_wandb_kwargs = {"project": "slowrun", "name": run_name, "dir": os.path.join(run_dir, "wandb")}
 if args.wandb_group:
     _wandb_kwargs["group"] = args.wandb_group
 wandb_run = DummyWandb() if not master_process else wandb.init(**_wandb_kwargs)
@@ -934,7 +1010,9 @@ print0(f"  matrix_lr={MATRIX_LR}, scalar_lr={SCALAR_LR}, embedding_lr={EMBEDDING
 print0(f"  weight_decay={WEIGHT_DECAY}, adam_betas={ADAM_BETAS}")
 print0(f"  warmup_ratio={WARMUP_RATIO}, warmdown_ratio={WARMDOWN_RATIO}, final_lr_frac={FINAL_LR_FRAC}")
 print0(f"  num_epochs={args.num_epochs}, patience={args.patience}")
-print0(f"  dropout={args.dropout}")
+print0(f"  dropout={args.dropout}, doc_shuffle={not args.no_doc_shuffle}")
+print0(f"  run={run_name}")
+print0(f"  run_dir={run_dir}")
 if args.iha:
     print0(f"  iha=True, iha_lr={args.iha_lr}")
 print0(f"-----------------------")
@@ -981,7 +1059,7 @@ optimizer = model.setup_optimizer()
 # Dataloaders
 _train_path = args.input_bin if args.input_bin else os.path.join(DATA_DIR, "fineweb_train.pt")
 _val_path = args.input_val_bin if args.input_val_bin else os.path.join(DATA_DIR, "fineweb_val.pt")
-train_loader = DataLoader(_train_path, args.device_batch_size, MAX_SEQ_LEN, device=device)
+train_loader = DataLoader(_train_path, args.device_batch_size, MAX_SEQ_LEN, device=device, doc_shuffle=not args.no_doc_shuffle)
 build_val_loader = lambda: DataLoader(_val_path, args.device_batch_size, MAX_SEQ_LEN, device=device)
 TOKENS_PER_EPOCH = train_loader.total_tokens
 x, y, current_epoch = next(train_loader)
@@ -1203,7 +1281,8 @@ print0(f"Min val Loss: {min_val_loss:.6f}")
 wandb_run.summary["final_train_loss"] = final_train_loss
 wandb_run.summary["best_val_loss"] = min_val_loss
 
-if args.save_result and master_process:
+_result_out = args.save_result or result_path
+if master_process:
     result = {
         "matrix_lr": args.matrix_lr,
         "weight_decay": args.weight_decay,
@@ -1212,9 +1291,9 @@ if args.save_result and master_process:
         "best_val_loss": min_val_loss,
         "wandb_url": getattr(wandb_run, "url", None),
     }
-    with open(args.save_result, "w") as f:
+    with open(_result_out, "w") as f:
         json.dump(result, f, indent=2)
-    print0(f"Result saved to {args.save_result}")
+    print0(f"Result saved to {_result_out}")
 
 total_wall_time = time.time() - _script_start
 print0(f"Total wall time: {total_wall_time:.2f}s ({total_wall_time/60:.2f}m)")
@@ -1222,3 +1301,9 @@ print0(f"Total wall time: {total_wall_time:.2f}s ({total_wall_time/60:.2f}m)")
 wandb_run.finish()
 if dist.is_initialized():
     dist.destroy_process_group()
+if artifacts_log_f is not None:
+    sys.stdout.flush()
+    sys.stderr.flush()
+    sys.stdout = stdout_orig
+    sys.stderr = stderr_orig
+    artifacts_log_f.close()

--- a/two_hour/train.py
+++ b/two_hour/train.py
@@ -12,12 +12,17 @@ import gc
 import math
 import time
 import json
+import sys
+import shutil
+import string
+import secrets
 import argparse
 from types import SimpleNamespace
 from functools import partial
 from dataclasses import dataclass
 from contextlib import nullcontext
 
+import numpy as np
 import torch
 import torch._dynamo
 torch._dynamo.config.cache_size_limit = 64
@@ -38,7 +43,8 @@ parser = argparse.ArgumentParser(description="Train GPT model")
 parser.add_argument("--device-batch-size", type=int, default=4)
 parser.add_argument("--num-epochs", type=int, default=11)
 parser.add_argument("--patience", type=int, default=-1)
-parser.add_argument("--run", type=str, default=None)
+parser.add_argument("--run-name", type=str, default=None,
+                    help="Run name under runs/ (default: random 6-char string)")
 parser.add_argument("--scalar-lr", type=float, default=0.1)
 parser.add_argument("--matrix-lr", type=float, default=0.04)
 parser.add_argument("--weight-decay", type=float, default=1.3)
@@ -88,6 +94,8 @@ parser.add_argument("--iha-lr", type=float, default=0.02,
                     help="LR for IHA mixing matrices")
 parser.add_argument("--window-schedule", type=str, default="",
                     help="Epoch-window schedule 'start-end:short,long;...'. Applies YaRN on long-window expansions.")
+parser.add_argument("--no-doc-shuffle", action="store_true",
+                    help="Disable per-epoch document reshuffling (still shuffles batch order)")
 args = parser.parse_args()
 args.window_schedule_spec = args.window_schedule.strip()
 
@@ -109,6 +117,8 @@ WINDOW_PATTERN = "SSSL"
 TOTAL_BATCH_SIZE = args.total_batch_size
 EVAL_TOKENS = 10_000_000
 DATA_DIR = "fineweb_data"
+BOS_ID = 50256  # <|endoftext|>
+RUNS_DIR = "runs"
 
 # Base optimizer hyperparameters
 BASE_MATRIX_LR = args.matrix_lr
@@ -210,6 +220,27 @@ class DummyWandb:
     def __init__(self): self.summary = {}
     def log(self, *a, **kw): pass
     def finish(self): pass
+
+class TeeStream:
+    """Save terminal output to file."""
+    def __init__(self, *streams):
+        self.streams = streams
+        self.encoding = getattr(streams[0], "encoding", "utf-8")
+    def write(self, data):
+        for stream in self.streams: stream.write(data)
+        return len(data)
+    def flush(self):
+        for stream in self.streams: stream.flush()
+    def isatty(self):
+        return any(getattr(stream, "isatty", lambda: False)() for stream in self.streams)
+    def fileno(self):
+        return self.streams[0].fileno()
+
+def resolve_run_dir(run_name):
+    if run_name:
+        return run_name, os.path.join(RUNS_DIR, run_name)
+    name = "".join(secrets.choice(string.ascii_lowercase + string.digits) for _ in range(6))
+    return name, os.path.join(RUNS_DIR, name)
 
 # =============================================================================
 def load_state_dict_into_model(model, state_dict):
@@ -870,53 +901,78 @@ class DistMuonAdamW(torch.optim.Optimizer):
 # =============================================================================
 
 class DataLoader:
-    """Pre-tokenized chunk dataloader. Yields (inputs, targets, epoch) forever."""
+    """Loads flat tokens, chunks into batches.
 
-    def __init__(self, filepath, B, T, device="cuda"):
+    doc_shuffle=False: applies the stored default sequence permutation (bitwise match
+    with the old chunked pipeline), shuffles batch order each epoch.
+    doc_shuffle=True: reshuffles documents each epoch, re-chunks, re-shuffles sequences.
+
+    Always yields (x, y, epoch).
+    """
+
+    def __init__(self, filepath, B, T, device="cuda", doc_shuffle=False):
         data = torch.load(filepath, weights_only=True)
-        chunks = data['chunks']
-        valid_counts = data['valid_counts']
-        file_B = data['batch_size']
-        sequence_size = data['sequence_size']
-        assert sequence_size == T + 1, f"Data sequence_size {sequence_size} != T+1={T+1}"
+        all_tokens = data["tokens"].long()
+        raw_doc_starts = data["doc_starts"].long()
+        bos_id = int(data["bos_id"])
+        assert bos_id == BOS_ID, f"data bos_id {bos_id} != expected {BOS_ID}"
 
-        # Gather all valid sequences into one tensor
-        all_seqs = []
-        for chunk, vc in zip(chunks, valid_counts):
-            rows = chunk.view(file_B, sequence_size)[:vc]
-            all_seqs.append(rows)
-        all_seqs = torch.cat(all_seqs, dim=0).long()  # (N, T+1)
+        doc_ends = torch.cat([raw_doc_starts[1:], torch.tensor([all_tokens.numel()])])
+        self.doc_tokens = [all_tokens[s:e] for s, e in zip(raw_doc_starts.tolist(), doc_ends.tolist())]
+        self.default_shuffle_seed = data["seq_shuffle_seed"]
 
-        # DDP sharding: each rank gets every world_size-th batch
         _, rank, _, world_size = get_dist_info()
-        seqs_per_step = B * world_size
+        self.rank = rank
+        self.world_size = world_size
+        self.device = device
+        self.B = B
+        self.T = T
+        self.seq_size = T + 1
+        self.doc_shuffle = doc_shuffle
+        self.epoch = 1
+        self._build_batches()
+
+    def _build_batches(self):
+        tokens = torch.cat(self.doc_tokens)
+        num_seqs = len(tokens) // self.seq_size
+        all_seqs = tokens[:num_seqs * self.seq_size].view(num_seqs, self.seq_size)
+        if self.doc_shuffle:
+            g = torch.Generator()
+            g.manual_seed(self.epoch + 1000)
+            all_seqs = all_seqs[torch.randperm(num_seqs, generator=g)]
+        else:
+            perm = np.random.RandomState(self.default_shuffle_seed).permutation(num_seqs)
+            all_seqs = all_seqs[torch.from_numpy(perm)]
+        seqs_per_step = self.B * self.world_size
         num_steps = len(all_seqs) // seqs_per_step
         usable = num_steps * seqs_per_step
-        all_seqs = all_seqs[:usable].view(num_steps, world_size, B, sequence_size)
-
-        self.rank_data = all_seqs[:, rank].contiguous()  # (num_steps, B, T+1)
+        all_seqs = all_seqs[:usable].view(num_steps, self.world_size, self.B, self.seq_size)
+        self.rank_data = all_seqs[:, self.rank].contiguous()
         self.num_steps = num_steps
-        self.total_tokens = usable * T  # trainable tokens across all ranks
-        self.device = device
+        self.total_tokens = usable * self.T
         self.pos = 0
-        self.epoch = 1
 
     def __iter__(self):
         return self
 
-    def _shuffle(self):
-        """Shuffle batch order for the new epoch, consistent across ranks."""
-        g = torch.Generator()
-        g.manual_seed(self.epoch)
-        perm = torch.randperm(self.num_steps, generator=g)
-        self.rank_data = self.rank_data[perm]
+    def _next_epoch(self):
+        self.epoch += 1
+        print0(f"Starting epoch {self.epoch}")
+        if self.doc_shuffle:
+            g = torch.Generator()
+            g.manual_seed(self.epoch)
+            perm = torch.randperm(len(self.doc_tokens), generator=g)
+            self.doc_tokens = [self.doc_tokens[i] for i in perm.tolist()]
+            self._build_batches()
+        else:
+            self.pos = 0
+            g = torch.Generator()
+            g.manual_seed(self.epoch)
+            self.rank_data = self.rank_data[torch.randperm(self.num_steps, generator=g)]
 
     def __next__(self):
         if self.pos >= self.num_steps:
-            self.pos = 0
-            self.epoch += 1
-            print0(f"Starting epoch {self.epoch}")
-            self._shuffle()
+            self._next_epoch()
         batch = self.rank_data[self.pos].to(self.device, non_blocking=True)
         self.pos += 1
         return batch[:, :-1].contiguous(), batch[:, 1:].contiguous(), self.epoch
@@ -1059,9 +1115,29 @@ if _fa3 is not None:
 else:
     raise RuntimeError("Flash Attention 3 is required but not available. A Hopper (sm90) GPU is needed.")
 
+# Run / logging paths
+run_name, run_dir = resolve_run_dir(args.run_name)
+if dist.is_initialized():
+    shared = [run_name]
+    dist.broadcast_object_list(shared, src=0)
+    run_name = shared[0]
+    run_dir = os.path.join(RUNS_DIR, run_name)
+checkpoints_dir = os.path.join(run_dir, "checkpoints")
+terminal_log_path = os.path.join(run_dir, "terminal.log")
+stdout_orig = sys.stdout
+stderr_orig = sys.stderr
+artifacts_log_f = None
+result_path = os.path.join(run_dir, "result.json")
+if master_process:
+    os.makedirs(checkpoints_dir, exist_ok=True)
+    os.makedirs(os.path.join(run_dir, "wandb"), exist_ok=True)
+    shutil.copy2(__file__, os.path.join(run_dir, "train.py"))
+    artifacts_log_f = open(terminal_log_path, "a", encoding="utf-8", buffering=1)
+    sys.stdout = TeeStream(sys.stdout, artifacts_log_f)
+    sys.stderr = TeeStream(sys.stderr, artifacts_log_f)
+
 # wandb
-run_name = args.run if args.run else time.strftime("%Y%m%d_%H%M%S")
-_wandb_kwargs = {"project": "slowrun", "name": run_name}
+_wandb_kwargs = {"project": "slowrun", "name": run_name, "dir": os.path.join(run_dir, "wandb")}
 if args.wandb_group:
     _wandb_kwargs["group"] = args.wandb_group
 wandb_run = DummyWandb() if not master_process else wandb.init(**_wandb_kwargs)
@@ -1079,7 +1155,9 @@ print0(f"  matrix_lr={MATRIX_LR}, scalar_lr={SCALAR_LR}, embedding_lr={EMBEDDING
 print0(f"  weight_decay={WEIGHT_DECAY}, adam_betas={ADAM_BETAS}")
 print0(f"  warmup_ratio={WARMUP_RATIO}, warmdown_ratio={WARMDOWN_RATIO}, final_lr_frac={FINAL_LR_FRAC}")
 print0(f"  num_epochs={args.num_epochs}, patience={args.patience}")
-print0(f"  dropout={args.dropout}")
+print0(f"  dropout={args.dropout}, doc_shuffle={not args.no_doc_shuffle}")
+print0(f"  run={run_name}")
+print0(f"  run_dir={run_dir}")
 if args.window_schedule:
     print0(f"  window_schedule={args.window_schedule_spec}")
 print0(f"-----------------------")
@@ -1134,7 +1212,7 @@ optimizer = model.setup_optimizer()
 # Dataloaders
 _train_path = args.input_bin if args.input_bin else os.path.join(DATA_DIR, "fineweb_train.pt")
 _val_path = args.input_val_bin if args.input_val_bin else os.path.join(DATA_DIR, "fineweb_val.pt")
-train_loader = DataLoader(_train_path, args.device_batch_size, MAX_SEQ_LEN, device=device)
+train_loader = DataLoader(_train_path, args.device_batch_size, MAX_SEQ_LEN, device=device, doc_shuffle=not args.no_doc_shuffle)
 build_val_loader = lambda: DataLoader(_val_path, args.device_batch_size, MAX_SEQ_LEN, device=device)
 TOKENS_PER_EPOCH = train_loader.total_tokens
 x, y, current_epoch = next(train_loader)
@@ -1370,7 +1448,8 @@ print0(f"Min val Loss: {min_val_loss:.6f}")
 wandb_run.summary["final_train_loss"] = final_train_loss
 wandb_run.summary["best_val_loss"] = min_val_loss
 
-if args.save_result and master_process:
+_result_out = args.save_result or result_path
+if master_process:
     result = {
         "matrix_lr": args.matrix_lr,
         "weight_decay": args.weight_decay,
@@ -1382,9 +1461,9 @@ if args.save_result and master_process:
         "best_val_loss": min_val_loss,
         "wandb_url": getattr(wandb_run, "url", None),
     }
-    with open(args.save_result, "w") as f:
+    with open(_result_out, "w") as f:
         json.dump(result, f, indent=2)
-    print0(f"Result saved to {args.save_result}")
+    print0(f"Result saved to {_result_out}")
 
 total_wall_time = time.time() - _script_start
 print0(f"Total wall time: {total_wall_time:.2f}s ({total_wall_time/60:.2f}m)")
@@ -1392,3 +1471,9 @@ print0(f"Total wall time: {total_wall_time:.2f}s ({total_wall_time/60:.2f}m)")
 wandb_run.finish()
 if dist.is_initialized():
     dist.destroy_process_group()
+if artifacts_log_f is not None:
+    sys.stdout.flush()
+    sys.stderr.flush()
+    sys.stdout = stdout_orig
+    sys.stderr = stderr_orig
+    artifacts_log_f.close()

--- a/two_hour/train.py
+++ b/two_hour/train.py
@@ -12,17 +12,13 @@ import gc
 import math
 import time
 import json
-import sys
-import shutil
-import string
-import secrets
+import numpy as np
 import argparse
 from types import SimpleNamespace
 from functools import partial
 from dataclasses import dataclass
 from contextlib import nullcontext
 
-import numpy as np
 import torch
 import torch._dynamo
 torch._dynamo.config.cache_size_limit = 64
@@ -43,8 +39,7 @@ parser = argparse.ArgumentParser(description="Train GPT model")
 parser.add_argument("--device-batch-size", type=int, default=4)
 parser.add_argument("--num-epochs", type=int, default=11)
 parser.add_argument("--patience", type=int, default=-1)
-parser.add_argument("--run-name", type=str, default=None,
-                    help="Run name under runs/ (default: random 6-char string)")
+parser.add_argument("--run", type=str, default=None)
 parser.add_argument("--scalar-lr", type=float, default=0.1)
 parser.add_argument("--matrix-lr", type=float, default=0.04)
 parser.add_argument("--weight-decay", type=float, default=1.3)
@@ -94,8 +89,6 @@ parser.add_argument("--iha-lr", type=float, default=0.02,
                     help="LR for IHA mixing matrices")
 parser.add_argument("--window-schedule", type=str, default="",
                     help="Epoch-window schedule 'start-end:short,long;...'. Applies YaRN on long-window expansions.")
-parser.add_argument("--no-doc-shuffle", action="store_true",
-                    help="Disable per-epoch document reshuffling (still shuffles batch order)")
 args = parser.parse_args()
 args.window_schedule_spec = args.window_schedule.strip()
 
@@ -117,8 +110,6 @@ WINDOW_PATTERN = "SSSL"
 TOTAL_BATCH_SIZE = args.total_batch_size
 EVAL_TOKENS = 10_000_000
 DATA_DIR = "fineweb_data"
-BOS_ID = 50256  # <|endoftext|>
-RUNS_DIR = "runs"
 
 # Base optimizer hyperparameters
 BASE_MATRIX_LR = args.matrix_lr
@@ -220,27 +211,6 @@ class DummyWandb:
     def __init__(self): self.summary = {}
     def log(self, *a, **kw): pass
     def finish(self): pass
-
-class TeeStream:
-    """Save terminal output to file."""
-    def __init__(self, *streams):
-        self.streams = streams
-        self.encoding = getattr(streams[0], "encoding", "utf-8")
-    def write(self, data):
-        for stream in self.streams: stream.write(data)
-        return len(data)
-    def flush(self):
-        for stream in self.streams: stream.flush()
-    def isatty(self):
-        return any(getattr(stream, "isatty", lambda: False)() for stream in self.streams)
-    def fileno(self):
-        return self.streams[0].fileno()
-
-def resolve_run_dir(run_name):
-    if run_name:
-        return run_name, os.path.join(RUNS_DIR, run_name)
-    name = "".join(secrets.choice(string.ascii_lowercase + string.digits) for _ in range(6))
-    return name, os.path.join(RUNS_DIR, name)
 
 # =============================================================================
 def load_state_dict_into_model(model, state_dict):
@@ -901,78 +871,49 @@ class DistMuonAdamW(torch.optim.Optimizer):
 # =============================================================================
 
 class DataLoader:
-    """Loads flat tokens, chunks into batches.
+    """Pre-tokenized dataloader. Yields (inputs, targets, epoch) forever."""
 
-    doc_shuffle=False: applies the stored default sequence permutation (bitwise match
-    with the old chunked pipeline), shuffles batch order each epoch.
-    doc_shuffle=True: reshuffles documents each epoch, re-chunks, re-shuffles sequences.
-
-    Always yields (x, y, epoch).
-    """
-
-    def __init__(self, filepath, B, T, device="cuda", doc_shuffle=False):
+    def __init__(self, filepath, B, T, device="cuda"):
         data = torch.load(filepath, weights_only=True)
         all_tokens = data["tokens"].long()
-        raw_doc_starts = data["doc_starts"].long()
-        bos_id = int(data["bos_id"])
-        assert bos_id == BOS_ID, f"data bos_id {bos_id} != expected {BOS_ID}"
+        sequence_size = T + 1
 
-        doc_ends = torch.cat([raw_doc_starts[1:], torch.tensor([all_tokens.numel()])])
-        self.doc_tokens = [all_tokens[s:e] for s, e in zip(raw_doc_starts.tolist(), doc_ends.tolist())]
-        self.default_shuffle_seed = data["seq_shuffle_seed"]
+        # Reconstruct the old sequence ordering from flat tokens
+        num_seqs = len(all_tokens) // sequence_size
+        all_seqs = all_tokens[:num_seqs * sequence_size].view(num_seqs, sequence_size)
+        perm = np.random.RandomState(data["seq_shuffle_seed"]).permutation(num_seqs)
+        all_seqs = all_seqs[torch.from_numpy(perm)]  # (N, T+1)
 
+        # DDP sharding: each rank gets every world_size-th batch
         _, rank, _, world_size = get_dist_info()
-        self.rank = rank
-        self.world_size = world_size
-        self.device = device
-        self.B = B
-        self.T = T
-        self.seq_size = T + 1
-        self.doc_shuffle = doc_shuffle
-        self.epoch = 1
-        self._build_batches()
-
-    def _build_batches(self):
-        tokens = torch.cat(self.doc_tokens)
-        num_seqs = len(tokens) // self.seq_size
-        all_seqs = tokens[:num_seqs * self.seq_size].view(num_seqs, self.seq_size)
-        if self.doc_shuffle:
-            g = torch.Generator()
-            g.manual_seed(self.epoch + 1000)
-            all_seqs = all_seqs[torch.randperm(num_seqs, generator=g)]
-        else:
-            perm = np.random.RandomState(self.default_shuffle_seed).permutation(num_seqs)
-            all_seqs = all_seqs[torch.from_numpy(perm)]
-        seqs_per_step = self.B * self.world_size
+        seqs_per_step = B * world_size
         num_steps = len(all_seqs) // seqs_per_step
         usable = num_steps * seqs_per_step
-        all_seqs = all_seqs[:usable].view(num_steps, self.world_size, self.B, self.seq_size)
-        self.rank_data = all_seqs[:, self.rank].contiguous()
+        all_seqs = all_seqs[:usable].view(num_steps, world_size, B, sequence_size)
+
+        self.rank_data = all_seqs[:, rank].contiguous()  # (num_steps, B, T+1)
         self.num_steps = num_steps
-        self.total_tokens = usable * self.T
+        self.total_tokens = usable * T  # trainable tokens across all ranks
+        self.device = device
         self.pos = 0
+        self.epoch = 1
 
     def __iter__(self):
         return self
 
-    def _next_epoch(self):
-        self.epoch += 1
-        print0(f"Starting epoch {self.epoch}")
-        if self.doc_shuffle:
-            g = torch.Generator()
-            g.manual_seed(self.epoch)
-            perm = torch.randperm(len(self.doc_tokens), generator=g)
-            self.doc_tokens = [self.doc_tokens[i] for i in perm.tolist()]
-            self._build_batches()
-        else:
-            self.pos = 0
-            g = torch.Generator()
-            g.manual_seed(self.epoch)
-            self.rank_data = self.rank_data[torch.randperm(self.num_steps, generator=g)]
+    def _shuffle(self):
+        """Shuffle batch order for the new epoch, consistent across ranks."""
+        g = torch.Generator()
+        g.manual_seed(self.epoch)
+        perm = torch.randperm(self.num_steps, generator=g)
+        self.rank_data = self.rank_data[perm]
 
     def __next__(self):
         if self.pos >= self.num_steps:
-            self._next_epoch()
+            self.pos = 0
+            self.epoch += 1
+            print0(f"Starting epoch {self.epoch}")
+            self._shuffle()
         batch = self.rank_data[self.pos].to(self.device, non_blocking=True)
         self.pos += 1
         return batch[:, :-1].contiguous(), batch[:, 1:].contiguous(), self.epoch
@@ -1115,29 +1056,9 @@ if _fa3 is not None:
 else:
     raise RuntimeError("Flash Attention 3 is required but not available. A Hopper (sm90) GPU is needed.")
 
-# Run / logging paths
-run_name, run_dir = resolve_run_dir(args.run_name)
-if dist.is_initialized():
-    shared = [run_name]
-    dist.broadcast_object_list(shared, src=0)
-    run_name = shared[0]
-    run_dir = os.path.join(RUNS_DIR, run_name)
-checkpoints_dir = os.path.join(run_dir, "checkpoints")
-terminal_log_path = os.path.join(run_dir, "terminal.log")
-stdout_orig = sys.stdout
-stderr_orig = sys.stderr
-artifacts_log_f = None
-result_path = os.path.join(run_dir, "result.json")
-if master_process:
-    os.makedirs(checkpoints_dir, exist_ok=True)
-    os.makedirs(os.path.join(run_dir, "wandb"), exist_ok=True)
-    shutil.copy2(__file__, os.path.join(run_dir, "train.py"))
-    artifacts_log_f = open(terminal_log_path, "a", encoding="utf-8", buffering=1)
-    sys.stdout = TeeStream(sys.stdout, artifacts_log_f)
-    sys.stderr = TeeStream(sys.stderr, artifacts_log_f)
-
 # wandb
-_wandb_kwargs = {"project": "slowrun", "name": run_name, "dir": os.path.join(run_dir, "wandb")}
+run_name = args.run if args.run else time.strftime("%Y%m%d_%H%M%S")
+_wandb_kwargs = {"project": "slowrun", "name": run_name}
 if args.wandb_group:
     _wandb_kwargs["group"] = args.wandb_group
 wandb_run = DummyWandb() if not master_process else wandb.init(**_wandb_kwargs)
@@ -1155,9 +1076,7 @@ print0(f"  matrix_lr={MATRIX_LR}, scalar_lr={SCALAR_LR}, embedding_lr={EMBEDDING
 print0(f"  weight_decay={WEIGHT_DECAY}, adam_betas={ADAM_BETAS}")
 print0(f"  warmup_ratio={WARMUP_RATIO}, warmdown_ratio={WARMDOWN_RATIO}, final_lr_frac={FINAL_LR_FRAC}")
 print0(f"  num_epochs={args.num_epochs}, patience={args.patience}")
-print0(f"  dropout={args.dropout}, doc_shuffle={not args.no_doc_shuffle}")
-print0(f"  run={run_name}")
-print0(f"  run_dir={run_dir}")
+print0(f"  dropout={args.dropout}")
 if args.window_schedule:
     print0(f"  window_schedule={args.window_schedule_spec}")
 print0(f"-----------------------")
@@ -1212,7 +1131,7 @@ optimizer = model.setup_optimizer()
 # Dataloaders
 _train_path = args.input_bin if args.input_bin else os.path.join(DATA_DIR, "fineweb_train.pt")
 _val_path = args.input_val_bin if args.input_val_bin else os.path.join(DATA_DIR, "fineweb_val.pt")
-train_loader = DataLoader(_train_path, args.device_batch_size, MAX_SEQ_LEN, device=device, doc_shuffle=not args.no_doc_shuffle)
+train_loader = DataLoader(_train_path, args.device_batch_size, MAX_SEQ_LEN, device=device)
 build_val_loader = lambda: DataLoader(_val_path, args.device_batch_size, MAX_SEQ_LEN, device=device)
 TOKENS_PER_EPOCH = train_loader.total_tokens
 x, y, current_epoch = next(train_loader)
@@ -1448,8 +1367,7 @@ print0(f"Min val Loss: {min_val_loss:.6f}")
 wandb_run.summary["final_train_loss"] = final_train_loss
 wandb_run.summary["best_val_loss"] = min_val_loss
 
-_result_out = args.save_result or result_path
-if master_process:
+if args.save_result and master_process:
     result = {
         "matrix_lr": args.matrix_lr,
         "weight_decay": args.weight_decay,
@@ -1461,9 +1379,9 @@ if master_process:
         "best_val_loss": min_val_loss,
         "wandb_url": getattr(wandb_run, "url", None),
     }
-    with open(_result_out, "w") as f:
+    with open(args.save_result, "w") as f:
         json.dump(result, f, indent=2)
-    print0(f"Result saved to {_result_out}")
+    print0(f"Result saved to {args.save_result}")
 
 total_wall_time = time.time() - _script_start
 print0(f"Total wall time: {total_wall_time:.2f}s ({total_wall_time/60:.2f}m)")
@@ -1471,9 +1389,3 @@ print0(f"Total wall time: {total_wall_time:.2f}s ({total_wall_time/60:.2f}m)")
 wandb_run.finish()
 if dist.is_initialized():
     dist.destroy_process_group()
-if artifacts_log_f is not None:
-    sys.stdout.flush()
-    sys.stderr.flush()
-    sys.stdout = stdout_orig
-    sys.stderr = stderr_orig
-    artifacts_log_f.close()

--- a/unlimited/train.py
+++ b/unlimited/train.py
@@ -27,6 +27,7 @@ import gc
 import math
 import time
 import json
+import numpy as np
 import argparse
 from types import SimpleNamespace
 from functools import partial
@@ -754,21 +755,18 @@ class DistMuonAdamW(torch.optim.Optimizer):
 # =============================================================================
 
 class DataLoader:
-    """Pre-tokenized chunk dataloader with per-epoch shuffling."""
+    """Pre-tokenized dataloader with per-epoch shuffling."""
 
     def __init__(self, filepath, B, T, device="cuda", seed=42):
         data = torch.load(filepath, weights_only=True)
-        chunks = data['chunks']
-        valid_counts = data['valid_counts']
-        file_B = data['batch_size']
-        sequence_size = data['sequence_size']
-        assert sequence_size == T + 1, f"Data sequence_size {sequence_size} != T+1={T+1}"
+        all_tokens = data["tokens"].long()
+        sequence_size = T + 1
 
-        all_seqs = []
-        for chunk, vc in zip(chunks, valid_counts):
-            rows = chunk.view(file_B, sequence_size)[:vc]
-            all_seqs.append(rows)
-        all_seqs = torch.cat(all_seqs, dim=0).long()
+        # Reconstruct token-identical sequence ordering from og dataloader.
+        num_seqs = len(all_tokens) // sequence_size
+        all_seqs = all_tokens[:num_seqs * sequence_size].view(num_seqs, sequence_size)
+        perm = np.random.RandomState(data["seq_shuffle_seed"]).permutation(num_seqs)
+        all_seqs = all_seqs[torch.from_numpy(perm)]  # (N, T+1)
 
         _, rank, _, world_size = get_dist_info()
         seqs_per_step = B * world_size
@@ -825,17 +823,14 @@ class DDPValLoader:
     """
     def __init__(self, filepath, B, T, rank, world_size, device="cuda", seed=0):
         data = torch.load(filepath, weights_only=True)
-        chunks = data['chunks']
-        valid_counts = data['valid_counts']
-        file_B = data['batch_size']
-        sequence_size = data['sequence_size']
-        assert sequence_size == T + 1, f"Data sequence_size {sequence_size} != T+1={T+1}"
+        all_tokens = data["tokens"].long()
+        sequence_size = T + 1
 
-        all_seqs = []
-        for chunk, vc in zip(chunks, valid_counts):
-            rows = chunk.view(file_B, sequence_size)[:vc]
-            all_seqs.append(rows)
-        all_seqs = torch.cat(all_seqs, dim=0).long()
+        # Reconstruct the old sequence ordering from flat tokens
+        num_seqs = len(all_tokens) // sequence_size
+        all_seqs = all_tokens[:num_seqs * sequence_size].view(num_seqs, sequence_size)
+        perm = np.random.RandomState(data["seq_shuffle_seed"]).permutation(num_seqs)
+        all_seqs = all_seqs[torch.from_numpy(perm)]  # (N, T+1)
 
         seqs_per_step = B * world_size
         num_steps = len(all_seqs) // seqs_per_step


### PR DESCRIPTION
Instead of shuffling the order of a fixed set of batches every epoch, shuffle the order of the documents in the training set, then tokenize into batches + re-shuffle.

[15' log file](https://github.com/user-attachments/files/26917051/terminal.log):
Old record: 3.345
New record: 3.332

[1hr log file](https://github.com/user-attachments/files/26917044/terminal.log):
Old record: 3.211
New record: 3.204

This is taking one of the many components of #67 so that comparison to previous results is straightforward. This does not change the eval tokens or batching at all -- all it does is make the training shuffle the documents before re-batching. This adds more training diversity as any given token is preceded by different tokens every epoch.

I also added 2 hour record which was pre-empted while running. Submitting now, hoping someone can run it. The code is backwards compatible with `--no-doc-shuffle`, and I added some QOL things like saving the log, training file, and checkpoints to a file. This not only makes dev easier, but also replication. I hope people adopt this standard of attaching logs.