### PR TITLE
Anti-phase WD sawtooth + sqrt warmdown shape (1 hr track)

### DIFF
--- a/train.py
+++ b/train.py
@@ -133,6 +133,10 @@ ADAM_BETAS = (0.8, 0.95)
 WARMUP_RATIO = 0.0
 WARMDOWN_RATIO = args.warmdown_ratio if args.warmdown_ratio is not None else 0.2
 FINAL_LR_FRAC = 0.0
+WARMDOWN_POWER = 0.5      # sqrt-shaped warmdown (stays ~41% higher at midpoint than linear)
+WD_PRE_HOLD_FRAC = 0.40   # hold at base WD for first 40% of training, then decay to LOW by SWA start
+WD_SWA_LOW_FACTOR = 0.65  # WD at start of each SWA epoch (LR is high → less regularization)
+WD_SWA_HIGH_FACTOR = 1.50 # WD at end of each SWA epoch (LR has decayed → more regularization)
 LOGIT_CAP = args.logit_cap
 
 # =============================================================================
@@ -1079,13 +1083,28 @@ def get_lr_multiplier(it):
     elif it <= num_iterations - warmdown: return 1.0
     else:
         progress = (num_iterations - it) / warmdown
-        return progress + (1 - progress) * FINAL_LR_FRAC
+        shaped = progress ** WARMDOWN_POWER  # concave (stays higher longer) when POWER < 1
+        return shaped + (1 - shaped) * FINAL_LR_FRAC
 
 def get_muon_momentum(it):
     return (1 - min(it / 300, 1)) * 0.85 + min(it / 300, 1) * 0.95
 
 steps_per_epoch = num_iterations / args.num_epochs
 _swa_start_step = (num_iterations - args.swa_last_epochs * steps_per_epoch) if args.swa_last_epochs > 0 else -1
+
+def get_wd_multiplier(it):
+    """Anti-phase WD: hold at 1.0 pre-SWA, decay to LOW by SWA start, then sawtooth LOW→HIGH per SWA epoch (anti-phase with the LR cosine cycle)."""
+    if _swa_start_step >= 0 and it >= _swa_start_step:
+        cycle_pos = (it - _swa_start_step) % steps_per_epoch
+        frac = cycle_pos / steps_per_epoch
+        return WD_SWA_LOW_FACTOR + (WD_SWA_HIGH_FACTOR - WD_SWA_LOW_FACTOR) * frac
+    t = it / num_iterations
+    if t < WD_PRE_HOLD_FRAC:
+        return 1.0
+    swa_start_frac = _swa_start_step / num_iterations if _swa_start_step > 0 else 1.0
+    decay_frac = (t - WD_PRE_HOLD_FRAC) / max(swa_start_frac - WD_PRE_HOLD_FRAC, 1e-6)
+    decay_frac = min(max(decay_frac, 0.0), 1.0)
+    return 1.0 - (1.0 - WD_SWA_LOW_FACTOR) * decay_frac
 
 # Training loop
 step = 0
@@ -1147,8 +1166,14 @@ while not args.eval_logit_avg and current_epoch <= args.num_epochs:
         cycle_pos = (step - _swa_start_step) % steps_per_epoch
         swa_base = max(lrm, 0.05)
         lrm = 0.05 + (swa_base - 0.05) * (1 + math.cos(math.pi * cycle_pos / steps_per_epoch)) / 2
+    # WD schedule: pre-SWA decay from base to 0.65×base, then anti-phase sawtooth
+    # during SWA's N epochs (0.65→1.50×base per epoch, anti-phase with LR cosine cycle).
+    wdm = get_wd_multiplier(step)
     for group in optimizer.param_groups:
         group["lr"] = group["initial_lr"] * lrm
+        if "initial_wd" not in group:
+            group["initial_wd"] = group.get("weight_decay", 0.0)
+        group["weight_decay"] = group["initial_wd"] * wdm
         if group['kind'] == 'muon':
             group["momentum"] = get_muon_momentum(step)
     optimizer.step()


### PR DESCRIPTION
In trying some other techniques, I noticed this had some delta on its own. If you add an anti-phase weight decay sawtooth during SWA's last 3 epochs it makes the checkpoints prob distributions average better. I also found that the old WD schedule was not optimal.

 The WD sawtooth ramps from 0.65× base WD at SWA epoch start (when LR is at its cosine peak) up to 1.50× at epoch end (when LR has decayed to ~0), anti-phase with the LR cycle — so the strongest regularization hits when the model is settling at low LR, not when it's exploring at high LR. The sqrt warmdown (lr_mult = progress^0.5) keeps LR higher for longer through the warmdown window, then drops sharply at the end.

https://wandb.ai/shmublu/slowrun/runs/agl2bmqx final val loss: 3.195 