### PR TITLE
Add new changes to hybrid attention track, update tilelang use, and update docs

### DIFF
--- a/research/hybrid_attn/README.md
+++ b/research/hybrid_attn/README.md
@@ -1,3 +1,38 @@
-# Hybrid attention 
+# Hybrid Attention
 
-This is an implementation of hybrid attention using [Gated DeltaNet](https://arxiv.org/abs/2412.06464), led by [@ChinmayK0607](https://x.com/ChinmayKak). It achieves 3.2458 val loss in ~81 minutes.
+Hybrid attention track led by [@ChinmayK0607](https://x.com/ChinmayKak).
+
+## Records
+
+| PR | Record | Time |
+| --- | --- | --- |
+| PR `#49` (`1f0fe74`) | `3.246` val loss | about `81` minutes |
+| PR `#58` (`5cb9428`) | `3.241282` val loss | `72.33` min training, `76.91` min wall |
+| KDA / FlashKDA extension | `3.239565` best val loss, `3.255612` final val loss | `89.28` min training, `94.42` min wall |
+
+## Usage
+
+GDN reference run:
+
+```bash
+torchrun --standalone --nproc_per_node=8 research/hybrid_attn/train.py \
+  --gdn-layers 1,3,5,6,8,10,11,13,15,16,18,20,22,23
+```
+
+KDA / FlashKDA run:
+
+```bash
+FLA_FLASH_KDA=1 torchrun --standalone --nproc_per_node=8 research/hybrid_attn/train.py \
+  --gdn-layers 1,3,5,6,8,10,11,13,15,16,18,20,22,23 \
+  --linear-attn-type kda
+```
+
+## Brief History
+
+1. PR `#49`: introduced the core hybrid idea. The theoretical change was to mix full softmax attention with GatedDeltaNet, so some layers use recurrent associative memory instead of recomputing all context from scratch. The negative-eigenvalue GDN state makes it easier to track changing latent state, not just accumulate information.
+
+2. PR `#58`: kept the same GDN theory, but improved the efficiency frontier of that idea. The important point was not a new inductive bias; it was making the same recurrent-memory-plus-softmax-correction story cheaper to run, so the track could realize more of the hybrid benefit within a practical time budget.
+
+3. KDA / FlashKDA: upgraded the recurrent memory from a single forget coefficient per head to a per-dimension forget mechanism. The theoretical effect is a more expressive state space, where one head can preserve different subspaces for different timescales instead of forcing the whole head to forget or retain together. That improved loss, but it also increased runtime.
+
+Best loss so far is KDA, but GDN stays the default because it is materially faster.

--- a/research/hybrid_attn/README.md
+++ b/research/hybrid_attn/README.md
@@ -1,4 +1,4 @@
-````md
+
 # Hybrid Attention
 
 Hybrid attention track led by [@ChinmayK0607](https://x.com/ChinmayKak).

--- a/research/hybrid_attn/README.md
+++ b/research/hybrid_attn/README.md
@@ -1,31 +1,97 @@
+````md
 # Hybrid Attention
 
 Hybrid attention track led by [@ChinmayK0607](https://x.com/ChinmayKak).
 
+Hybrid attention mixes full softmax layers with linear-attention layers inside the same 30-layer trainer. The trainer supports both GDN and KDA on the same alternating-layer layout, plus hybrid-specific optimizer and dataloader controls used in recent experiments.
+
+On Hopper hosts, full GDN training should use:
+
+```bash
+FLA_TILELANG=1
+````
+
+## Current Leaderboard
+
+| Rank | Backend     | Best / Final Val Loss | Training Time | Peak Memory    | Notes                                               |
+| ---- | ----------- | --------------------- | ------------- | -------------- | --------------------------------------------------- |
+| 1    | GDN         | `3.230877 / 3.243014` | `80.38` min   | `54820.06` MiB | Current quality-best baseline with `--muon-eq-r`    |
+| 2    | GDN no-conv | `3.234275 / 3.246534` | `71.93` min   | `53583.05` MiB | Current speed-quality frontier with `--gdn-no-conv` |
+| 3    | KDA         | `3.239565 / 3.255612` | `89.28` min   | `57735.46` MiB | Slower quality reference line                       |
+| 4    | GDN         | `3.234646 / 3.247445` | `80.37` min   | `54820.06` MiB | TileLang GDN control before MuonEq-R                |
+
 ## Records
 
-| PR | Record | Time |
-| --- | --- | --- |
-| PR `#49` (`1f0fe74`) | `3.246` val loss | about `81` minutes |
-| PR `#58` (`5cb9428`) | `3.241282` val loss | `72.33` min training, `76.91` min wall |
-| KDA / FlashKDA extension | `3.239565` best val loss, `3.255612` final val loss | `89.28` min training, `94.42` min wall |
+| PR / Run                              | Record                                              | Time                                   |
+| ------------------------------------- | --------------------------------------------------- | -------------------------------------- |
+| PR `#49` (`1f0fe74`)                  | `3.246` val loss                                    | about `81` minutes                     |
+| PR `#58` (`5cb9428`)                  | `3.241282` val loss                                 | `72.33` min training, `76.91` min wall |
+| KDA / FlashKDA extension              | `3.239565` best val loss, `3.255612` final val loss | `89.28` min training, `94.42` min wall |
+| Current GDN quality-best              | `3.230877` best val loss, `3.243014` final val loss | `80.38` min training                   |
+| Current GDN no-conv speed-quality run | `3.234275` best val loss, `3.246534` final val loss | `71.93` min training                   |
 
 ## Usage
 
-GDN reference run:
+Current quality-best GDN default:
+
+```bash
+FLA_TILELANG=1 torchrun --standalone --nproc_per_node=8 research/hybrid_attn/train.py \
+  --gdn-layers 1,3,5,6,8,10,11,13,15,16,18,20,22,23 \
+  --linear-attn-type gdn \
+  --muon-eq-r
+```
+
+Current faster GDN alternative:
+
+```bash
+FLA_TILELANG=1 torchrun --standalone --nproc_per_node=8 research/hybrid_attn/train.py \
+  --gdn-layers 1,3,5,6,8,10,11,13,15,16,18,20,22,23 \
+  --linear-attn-type gdn \
+  --muon-eq-r \
+  --gdn-no-conv
+```
+
+Current KDA / FlashKDA reference run:
 
 ```bash
 torchrun --standalone --nproc_per_node=8 research/hybrid_attn/train.py \
-  --gdn-layers 1,3,5,6,8,10,11,13,15,16,18,20,22,23
+  --gdn-layers 1,3,5,6,8,10,11,13,15,16,18,20,22,23 \
+  --linear-attn-type kda \
+  --muon-eq-r
 ```
 
-KDA / FlashKDA run:
+Older KDA / FlashKDA runs may also use:
 
 ```bash
 FLA_FLASH_KDA=1 torchrun --standalone --nproc_per_node=8 research/hybrid_attn/train.py \
   --gdn-layers 1,3,5,6,8,10,11,13,15,16,18,20,22,23 \
   --linear-attn-type kda
 ```
+
+## Trainer Options
+
+* `--linear-attn-type {gdn,kda}` switches the linear-attention block used on the selected hybrid layers.
+* `--gdn-no-conv` disables the GDN short-convolution path and is the current best runtime-saving knob.
+* `--muon-eq-r` enables row-normalized Muon updates and is part of the current quality-best hybrid baseline.
+* `--muon-ns-schedule {polar-express,deepseek-v4}` switches the Muon Newton-Schulz coefficient table.
+* `--no-doc-shuffle` disables per-epoch document reshuffling when using the flat-token dataset format.
+* `--grad-clip <value>` enables global gradient-norm clipping before the optimizer step.
+* `--gdn-use-recurrent` remains experimental and should not be treated as a stable default.
+
+## Practical Guidance
+
+Use the quality-best GDN run as the control for new quality-focused GDN follow-ups.
+
+Use the GDN no-conv variant when runtime matters more than the last `0.003-0.004` of validation loss.
+
+Treat KDA as a reference backend, not the default deployment path on this host. KDA still gives a strong quality reference, but it is materially slower.
+
+For Hopper GDN runs, prefer `FLA_TILELANG=1`. The older non-TileLang GDN path is no longer the right frontier comparison.
+
+## In-Flight Follow-Ups
+
+* Test `--muon-ns-schedule deepseek-v4` on top of the current quality-best GDN baseline.
+* Test `--grad-clip 1.0` on top of the current quality-best GDN baseline as a stability-only A/B.
 
 ## Brief History
 
@@ -35,4 +101,11 @@ FLA_FLASH_KDA=1 torchrun --standalone --nproc_per_node=8 research/hybrid_attn/tr
 
 3. KDA / FlashKDA: upgraded the recurrent memory from a single forget coefficient per head to a per-dimension forget mechanism. The theoretical effect is a more expressive state space, where one head can preserve different subspaces for different timescales instead of forcing the whole head to forget or retain together. That improved loss, but it also increased runtime.
 
-Best loss so far is KDA, but GDN stays the default because it is materially faster.
+4. Current GDN quality-best: moved the GDN frontier onto the Hopper TileLang path and added `--muon-eq-r`, improving the best validation loss to `3.230877`.
+
+5. Current GDN no-conv speed-quality run: disabled the GDN short-convolution path with `--gdn-no-conv`, giving the current speed-quality frontier. It is faster than the quality-best GDN run while giving up only a small amount of validation loss.
+
+Best loss so far is now the GDN + TileLang + MuonEq-R run. KDA remains an important reference backend, but GDN stays the default because it is faster and currently gives the best overall frontier on this host.
+
+```
+```

--- a/research/hybrid_attn/train.py
+++ b/research/hybrid_attn/train.py
@@ -3,13 +3,7 @@ Train a language model on ~100M tokens with val loss evaluation.
 Code is based on Nanochat (https://github.com/karpathy/nanochat), with modifications to support the slowrun setting.
 
 Usage:
-   torchrun --standalone --nproc_per_node=8 train.py --gdn-layers "1,3,5,7,9,11,13,16,18,20,22,24,26,28"
-   Performance reference (8×H100, 12 epochs, alternating-14 layout):
-      Config: --gdn-layers 1,3,5,6,8,10,11,13,15,16,18,20,22,23 (14 GDN / 16 softmax)
-      Min val BPB: 1.053290                                                                                                                    
-      Min val Loss: 3.241282 
-      Total training time: 72.33m                                                                                                                                                              json                                       
-      Total wall time: 4614.82s (76.91m)     
+   torchrun --standalone --nproc_per_node=8 train.py --gdn-layers "1,3,5,7,9,11,13,16,18,20,22,24,26,28"  
 """
 
 import os
@@ -34,6 +28,7 @@ import tiktoken
 
 # Gated Delta Net kernels (flash-linear-attention)
 from fla.ops.gated_delta_rule import chunk_gated_delta_rule, fused_recurrent_gated_delta_rule
+from fla.ops.kda import chunk_kda
 
 _script_start = time.time()
 _THIS_DIR = os.path.dirname(os.path.abspath(__file__))
@@ -94,6 +89,8 @@ parser.add_argument("--gdn-use-recurrent", action="store_true",
                     help="Use the experimental fused recurrent GDN kernel instead of chunked mode")
 parser.add_argument("--gdn-profile", action="store_true",
                     help="Enable lightweight GDN timing attribution (runs in eager mode)")
+parser.add_argument("--linear-attn-type", type=str, default="gdn", choices=("gdn", "kda"),
+                    help="Linear-attention block to use on the layers selected by --gdn-layers")
 args = parser.parse_args()
 
 # Resolve output path
@@ -299,6 +296,7 @@ class GPTConfig:
     gdn_no_conv: bool = False
     gdn_use_recurrent: bool = False
     gdn_profile: bool = False
+    linear_attn_type: str = "gdn"
 
 def norm(x):
     return F.rms_norm(x, (x.size(-1),))
@@ -489,6 +487,131 @@ class GatedDeltaNetAttention(nn.Module):
         return self.resid_dropout(self.o_proj(o))
 
 
+class KimiDeltaAttention(nn.Module):
+    """KDA block with a FlashKDA-compatible chunk_kda call shape.
+
+    Training uses the FLA Triton autograd path. Eval/no-grad can auto-dispatch
+    to FlashKDA when the external package is installed.
+    """
+
+    def __init__(self, config, layer_idx):
+        super().__init__()
+        self.n_embd = config.n_embd
+        self.num_heads = config.n_head
+        self.head_k_dim = config.n_embd // config.n_head
+        self.head_v_dim = self.head_k_dim
+        self.key_dim = self.num_heads * self.head_k_dim
+        self.value_dim = self.num_heads * self.head_v_dim
+        self.layer_idx = layer_idx
+        self.use_short_conv = not config.gdn_no_conv
+        self.safe_gate = True
+        self.lower_bound = -5.0
+
+        self.q_proj = nn.Linear(config.n_embd, self.key_dim, bias=False)
+        self.k_proj = nn.Linear(config.n_embd, self.key_dim, bias=False)
+        self.v_proj = nn.Linear(config.n_embd, self.value_dim, bias=False)
+        self.f_proj = nn.Sequential(
+            nn.Linear(config.n_embd, self.head_v_dim, bias=False),
+            nn.Linear(self.head_v_dim, self.key_dim, bias=False),
+        )
+        self.b_proj = nn.Linear(config.n_embd, self.num_heads, bias=False)
+        self.g_proj = nn.Sequential(
+            nn.Linear(config.n_embd, self.head_v_dim, bias=False),
+            nn.Linear(self.head_v_dim, self.value_dim, bias=False),
+        )
+        self.o_proj = nn.Linear(self.value_dim, config.n_embd, bias=False)
+
+        self.A_log = nn.Parameter(torch.zeros(self.num_heads, dtype=torch.float32))
+        self.A_log._no_weight_decay = True
+
+        dt = torch.exp(
+            torch.rand(self.key_dim, dtype=torch.float32) * (math.log(0.1) - math.log(0.001))
+            + math.log(0.001)
+        ).clamp(min=1e-4)
+        inv_dt = dt + torch.log(-torch.expm1(-dt))
+        self.dt_bias = nn.Parameter(inv_dt)
+        self.dt_bias._no_weight_decay = True
+
+        self.conv_size = 4
+        if self.use_short_conv:
+            self.q_conv = nn.Conv1d(self.key_dim, self.key_dim, self.conv_size,
+                                   padding=self.conv_size - 1, groups=self.key_dim, bias=False)
+            self.k_conv = nn.Conv1d(self.key_dim, self.key_dim, self.conv_size,
+                                   padding=self.conv_size - 1, groups=self.key_dim, bias=False)
+            self.v_conv = nn.Conv1d(self.value_dim, self.value_dim, self.conv_size,
+                                   padding=self.conv_size - 1, groups=self.value_dim, bias=False)
+        else:
+            self.q_conv = None
+            self.k_conv = None
+            self.v_conv = None
+
+        self.resid_dropout = nn.Dropout(config.dropout)
+
+    def _apply_short_conv(self, x, conv, T):
+        if conv is None:
+            return F.silu(x)
+        return F.silu(conv(x.transpose(1, 2))[:, :, :T].transpose(1, 2))
+
+    def forward(self, x, ve, cos_sin, window_size):
+        del ve, cos_sin, window_size
+        B, T, C = x.size()
+
+        with gdn_profiler.section("kda/proj"):
+            q = self.q_proj(x)
+            k = self.k_proj(x)
+            v = self.v_proj(x)
+            g = self.f_proj(x)
+            beta = self.b_proj(x)
+            g_out = self.g_proj(x)
+
+        with gdn_profiler.section("kda/conv"):
+            q = self._apply_short_conv(q, self.q_conv, T)
+            k = self._apply_short_conv(k, self.k_conv, T)
+            v = self._apply_short_conv(v, self.v_conv, T)
+
+        q = q.view(B, T, self.num_heads, self.head_k_dim).contiguous()
+        k = k.view(B, T, self.num_heads, self.head_k_dim).contiguous()
+        v = v.view(B, T, self.num_heads, self.head_v_dim).contiguous()
+        g = g.view(B, T, self.num_heads, self.head_k_dim).contiguous()
+        beta_logits = beta.contiguous()
+
+        use_flashkda_compatible_eval = not torch.is_grad_enabled()
+        if use_flashkda_compatible_eval:
+            beta = beta_logits.to(q.dtype)
+            use_beta_sigmoid_in_kernel = True
+            transpose_state_layout = True
+        else:
+            beta = torch.sigmoid(beta_logits).to(q.dtype)
+            use_beta_sigmoid_in_kernel = False
+            transpose_state_layout = False
+
+        with gdn_profiler.section("kda/kernel"):
+            o, _ = chunk_kda(
+                q=q,
+                k=k,
+                v=v,
+                g=g.to(q.dtype),
+                beta=beta,
+                A_log=self.A_log,
+                dt_bias=self.dt_bias,
+                scale=self.head_k_dim ** -0.5,
+                output_final_state=False,
+                use_qk_l2norm_in_kernel=True,
+                use_gate_in_kernel=True,
+                use_beta_sigmoid_in_kernel=use_beta_sigmoid_in_kernel,
+                safe_gate=self.safe_gate,
+                lower_bound=self.lower_bound,
+                transpose_state_layout=transpose_state_layout,
+            )
+
+        with gdn_profiler.section("kda/output"):
+            g_out = g_out.view(B, T, self.num_heads, self.head_v_dim)
+            o = F.rms_norm(o, (self.head_v_dim,)) * torch.sigmoid(g_out)
+
+        o = o.reshape(B, T, self.value_dim)
+        return self.resid_dropout(self.o_proj(o))
+
+
 class MLP(nn.Module):
     def __init__(self, config):
         super().__init__()
@@ -504,9 +627,13 @@ class MLP(nn.Module):
 class Block(nn.Module):
     def __init__(self, config, layer_idx):
         super().__init__()
-        self.is_gdn = config.gdn_layers is not None and layer_idx in config.gdn_layers
+        self.is_linear_attn = config.gdn_layers is not None and layer_idx in config.gdn_layers
+        self.is_gdn = self.is_linear_attn and config.linear_attn_type == "gdn"
+        self.is_kda = self.is_linear_attn and config.linear_attn_type == "kda"
         if self.is_gdn:
             self.attn = GatedDeltaNetAttention(config, layer_idx)
+        elif self.is_kda:
+            self.attn = KimiDeltaAttention(config, layer_idx)
         else:
             self.attn = CausalSelfAttention(config, layer_idx)
         self.mlp = MLP(config)
@@ -583,6 +710,25 @@ class GPT(nn.Module):
                 for conv in [attn.q_conv, attn.k_conv, attn.v_conv]:
                     if conv is not None:
                         torch.nn.init.normal_(conv.weight, std=0.02)
+            elif block.is_kda:
+                attn = block.attn
+                torch.nn.init.uniform_(attn.q_proj.weight, -s, s)
+                torch.nn.init.uniform_(attn.k_proj.weight, -s, s)
+                torch.nn.init.uniform_(attn.v_proj.weight, -s, s)
+                torch.nn.init.uniform_(attn.f_proj[0].weight, -s, s)
+                torch.nn.init.uniform_(attn.f_proj[1].weight, -s, s)
+                torch.nn.init.uniform_(attn.b_proj.weight, -s, s)
+                torch.nn.init.uniform_(attn.g_proj[0].weight, -s, s)
+                torch.nn.init.uniform_(attn.g_proj[1].weight, -s, s)
+                torch.nn.init.zeros_(attn.o_proj.weight)
+                attn.A_log.zero_()
+                dt = torch.exp(
+                    torch.rand_like(attn.dt_bias) * (math.log(0.1) - math.log(0.001)) + math.log(0.001)
+                ).clamp(min=1e-4)
+                attn.dt_bias.copy_(dt + torch.log(-torch.expm1(-dt)))
+                for conv in [attn.q_conv, attn.k_conv, attn.v_conv]:
+                    if conv is not None:
+                        torch.nn.init.normal_(conv.weight, std=0.02)
             else:
                 # Standard attention init
                 torch.nn.init.uniform_(block.attn.c_q.weight, -s, s)
@@ -597,7 +743,7 @@ class GPT(nn.Module):
         for proj in self.ve_projs.values():
             torch.nn.init.uniform_(proj.weight, -s, s)
         for block in self.transformer.h:
-            if not block.is_gdn:
+            if not block.is_linear_attn:
                 if block.attn.ve_gate is not None:
                     torch.nn.init.zeros_(block.attn.ve_gate.weight)
                 torch.nn.init.zeros_(block.attn.attn_gate.weight)
@@ -648,12 +794,15 @@ class GPT(nn.Module):
         gdn_scalar_ids = set()
         gdn_scalar_params = []
         for block in self.transformer.h:
-            if block.is_gdn:
-                for p in [block.attn.A_log, block.attn.dt_bias, block.attn.beta_bias]:
+            if block.is_linear_attn:
+                scalar_params = [block.attn.A_log, block.attn.dt_bias]
+                if hasattr(block.attn, "beta_bias"):
+                    scalar_params.append(block.attn.beta_bias)
+                for p in scalar_params:
                     gdn_scalar_ids.add(id(p))
                     gdn_scalar_params.append(p)
-                # b_proj bias is a tiny 1D vector — treat as scalar, not matrix
-                if block.attn.b_proj.bias is not None:
+                # Tiny 1D biases should stay on AdamW, not Muon.
+                if getattr(block.attn.b_proj, "bias", None) is not None:
                     gdn_scalar_ids.add(id(block.attn.b_proj.bias))
                     gdn_scalar_params.append(block.attn.b_proj.bias)
                 for conv in [block.attn.q_conv, block.attn.k_conv, block.attn.v_conv]:
@@ -1067,6 +1216,7 @@ print0(f"  weight_decay={WEIGHT_DECAY}, adam_betas={ADAM_BETAS}")
 print0(f"  warmup_ratio={WARMUP_RATIO}, warmdown_ratio={WARMDOWN_RATIO}, final_lr_frac={FINAL_LR_FRAC}")
 print0(f"  num_epochs={args.num_epochs}, patience={args.patience}")
 print0(f"  dropout={args.dropout}")
+print0(f"  linear_attn_type={args.linear_attn_type}")
 print0(f"  gdn_no_conv={args.gdn_no_conv}, gdn_use_recurrent={args.gdn_use_recurrent}, gdn_profile={args.gdn_profile}")
 print0(f"-----------------------")
 
@@ -1074,6 +1224,12 @@ if args.gdn_profile:
     print0("GDN profiling enabled; running in eager mode to keep section timings meaningful")
 if args.gdn_use_recurrent:
     print0("Experimental recurrent GDN kernel requested; chunk-kernel fallback remains enabled")
+if args.linear_attn_type == "kda" and args.gdn_use_recurrent:
+    raise RuntimeError("--gdn-use-recurrent is only implemented for --linear-attn-type gdn")
+if args.linear_attn_type == "kda" and HEAD_DIM != 128:
+    raise RuntimeError(
+        f"--linear-attn-type kda requires head_dim=128 for FlashKDA-compatible dispatch; got {HEAD_DIM}"
+    )
 
 def recurrent_gdn_backward_supported():
     if not args.gdn_use_recurrent:
@@ -1138,10 +1294,11 @@ else:
     gdn_layer_indices = [int(x.strip()) for x in args.gdn_layers.split(',') if x.strip()]
 
 if gdn_layer_indices:
-    print0(f"GatedDeltaNet layers ({len(gdn_layer_indices)}): {gdn_layer_indices}")
+    linear_attn_label = "GatedDeltaNet" if args.linear_attn_type == "gdn" else "KDA"
+    print0(f"{linear_attn_label} layers ({len(gdn_layer_indices)}): {gdn_layer_indices}")
     print0(f"Softmax attention layers ({DEPTH - len(gdn_layer_indices)}): {[i for i in range(DEPTH) if i not in gdn_layer_indices]}")
 else:
-    print0("All layers use standard softmax attention (no GDN)")
+    print0("All layers use standard softmax attention (no linear-attention layers)")
 
 # Build model
 config = GPTConfig(
@@ -1151,6 +1308,7 @@ config = GPTConfig(
     gdn_no_conv=args.gdn_no_conv,
     gdn_use_recurrent=args.gdn_use_recurrent,
     gdn_profile=args.gdn_profile,
+    linear_attn_type=args.linear_attn_type,
 )
 with torch.device("meta"):
     model = GPT(config)

--- a/research/hybrid_attn/train.py
+++ b/research/hybrid_attn/train.py
@@ -3,7 +3,13 @@ Train a language model on ~100M tokens with val loss evaluation.
 Code is based on Nanochat (https://github.com/karpathy/nanochat), with modifications to support the slowrun setting.
 
 Usage:
-   torchrun --standalone --nproc_per_node=8 train.py --gdn-layers "1,3,5,7,9,11,13,16,18,20,22,24,26,28"  
+   torchrun --standalone --nproc_per_node=8 train.py --gdn-layers "1,3,5,7,9,11,13,16,18,20,22,24,26,28"
+   Performance reference (8×H100, 12 epochs, alternating-14 layout):
+      Config: --gdn-layers 1,3,5,6,8,10,11,13,15,16,18,20,22,23 (14 GDN / 16 softmax)
+      Min val BPB: 1.053290                                                                                                                    
+      Min val Loss: 3.241282 
+      Total training time: 72.33m                                                                                                                                                              json                                       
+      Total wall time: 4614.82s (76.91m)     
 """
 
 import os
@@ -12,13 +18,13 @@ import gc
 import math
 import time
 import json
-import numpy as np
 import argparse
 from types import SimpleNamespace
 from functools import partial
 from dataclasses import dataclass
 from contextlib import nullcontext
 
+import numpy as np
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
@@ -64,6 +70,13 @@ parser.add_argument("--input_val_bin", type=str, default=None)
 parser.add_argument("--output_json", type=str, default=None)
 parser.add_argument("--wandb_group", type=str, default=None)
 parser.add_argument("--dropout", type=float, default=0.1)
+parser.add_argument("--muon-eq-r", action="store_true", dest="muon_eq_r", default=True,
+                    help="Enable MuonEq-R row normalization in the Muon path")
+parser.add_argument("--no-muon-eq-r", action="store_false", dest="muon_eq_r",
+                    help="Disable MuonEq-R row normalization in the Muon path")
+parser.add_argument("--muon-ns-schedule", type=str, default="polar-express",
+                    choices=("polar-express", "deepseek-v4"),
+                    help="Newton-Schulz coefficient schedule for Muon orthogonalization")
 parser.add_argument("--dupe-start-epoch", type=int, default=7,
                     help="Epoch to enable layer duplication")
 parser.add_argument("--dupe-layers-start", type=int, default=15,
@@ -80,6 +93,8 @@ parser.add_argument("--ema-start-frac", type=float, default=0.90,
                     help="Fraction of training after which to start EMA tracking")
 parser.add_argument("--checkpoint-avg", type=int, default=0,
                     help="Number of late checkpoints to average (0=disabled)")
+parser.add_argument("--grad-clip", type=float, default=0.0,
+                    help="Clip global grad norm before optimizer step (0=disabled)")
 parser.add_argument("--logit-cap", type=float, default=10.0,
                     help="Logit soft-capping value (0=disabled)")
 parser.add_argument("--gdn-layers", type=str, default="auto",
@@ -92,6 +107,8 @@ parser.add_argument("--gdn-profile", action="store_true",
                     help="Enable lightweight GDN timing attribution (runs in eager mode)")
 parser.add_argument("--linear-attn-type", type=str, default="gdn", choices=("gdn", "kda"),
                     help="Linear-attention block to use on the layers selected by --gdn-layers")
+parser.add_argument("--no-doc-shuffle", action="store_true",
+                    help="Disable per-epoch document reshuffling (still shuffles batch order)")
 args = parser.parse_args()
 
 # Resolve output path
@@ -115,6 +132,7 @@ DATA_DIR = _first_existing_path([
     os.path.abspath(os.path.join(_THIS_DIR, "..", "..", "fineweb_data")),
     os.path.abspath(os.path.join(_THIS_DIR, "..", "..", "..", "fineweb_data")),
 ])
+BOS_ID = 50256  # <|endoftext|>
 
 # Base optimizer hyperparameters
 BASE_MATRIX_LR = args.matrix_lr
@@ -835,7 +853,8 @@ class GPT(nn.Module):
         for shape in sorted({p.shape for p in matrix_params}):
             group_params = [p for p in matrix_params if p.shape == shape]
             param_groups.append(dict(kind='muon', params=group_params, lr=MATRIX_LR,
-                                     momentum=0.95, ns_steps=5, beta2=0.95, weight_decay=WEIGHT_DECAY))
+                                     momentum=0.95, ns_steps=len(muon_ns_coeffs), beta2=0.95,
+                                     weight_decay=WEIGHT_DECAY, muon_eq_r=args.muon_eq_r))
 
         optimizer = DistMuonAdamW(param_groups)
         for group in optimizer.param_groups:
@@ -906,6 +925,16 @@ polar_express_coeffs = [
     (2.3465413258596377, -1.7097828382687081, 0.42323551169305323),
 ]
 
+deepseek_v4_ns_coeffs = (
+    [(3.4445, -4.7750, 2.0315)] * 8
+    + [(2.0, -1.5, 0.5)] * 2
+)
+
+muon_ns_coeffs = {
+    "polar-express": polar_express_coeffs,
+    "deepseek-v4": deepseek_v4_ns_coeffs,
+}[args.muon_ns_schedule]
+
 @torch.compile(dynamic=False, fullgraph=True)
 def adamw_step_fused(p, grad, exp_avg, exp_avg_sq, step_t, lr_t, beta1_t, beta2_t, eps_t, wd_t):
     p.mul_(1 - lr_t * wd_t)
@@ -925,11 +954,11 @@ def muon_step_fused(stacked_grads, stacked_params, momentum_buffer, second_momen
     X = g.bfloat16()
     X = X / (X.norm(dim=(-2, -1), keepdim=True) * 1.02 + 1e-6)
     if g.size(-2) > g.size(-1):
-        for a, b, c in polar_express_coeffs[:ns_steps]:
+        for a, b, c in muon_ns_coeffs[:ns_steps]:
             A = X.mT @ X
             X = a * X + X @ (b * A + c * (A @ A))
     else:
-        for a, b, c in polar_express_coeffs[:ns_steps]:
+        for a, b, c in muon_ns_coeffs[:ns_steps]:
             A = X @ X.mT
             X = a * X + (b * A + c * (A @ A)) @ X
     g = X
@@ -946,6 +975,40 @@ def muon_step_fused(stacked_grads, stacked_params, momentum_buffer, second_momen
     final_scale = step_size * (v_norm / v_norm_new.clamp_min(1e-10))
     g = g * final_scale.to(g.dtype)
     # Cautious weight decay + update
+    lr = lr_t.to(g.dtype)
+    wd = wd_t.to(g.dtype)
+    mask = (g * stacked_params) >= 0
+    stacked_params.sub_(lr * g + lr * wd * stacked_params * mask)
+
+@torch.compile(dynamic=False, fullgraph=True)
+def muon_step_fused_eqr(stacked_grads, stacked_params, momentum_buffer, second_momentum_buffer,
+                        momentum_t, lr_t, wd_t, beta2_t, ns_steps, red_dim):
+    momentum = momentum_t.to(stacked_grads.dtype)
+    momentum_buffer.lerp_(stacked_grads, 1 - momentum)
+    g = stacked_grads.lerp_(momentum_buffer, momentum)
+    g /= g.float().norm(dim=-1, keepdim=True).clamp_min(1e-7).to(g.dtype)
+    X = g.bfloat16()
+    X = X / (X.norm(dim=(-2, -1), keepdim=True) * 1.02 + 1e-6)
+    if g.size(-2) > g.size(-1):
+        for a, b, c in muon_ns_coeffs[:ns_steps]:
+            A = X.mT @ X
+            X = a * X + X @ (b * A + c * (A @ A))
+    else:
+        for a, b, c in muon_ns_coeffs[:ns_steps]:
+            A = X @ X.mT
+            X = a * X + (b * A + c * (A @ A)) @ X
+    g = X
+    beta2 = beta2_t.to(g.dtype)
+    v_mean = g.float().square().mean(dim=red_dim, keepdim=True)
+    red_dim_size = g.size(red_dim)
+    v_norm_sq = v_mean.sum(dim=(-2, -1), keepdim=True) * red_dim_size
+    v_norm = v_norm_sq.sqrt()
+    second_momentum_buffer.lerp_(v_mean.to(dtype=second_momentum_buffer.dtype), 1 - beta2)
+    step_size = second_momentum_buffer.clamp_min(1e-10).rsqrt()
+    scaled_sq_sum = (v_mean * red_dim_size) * step_size.float().square()
+    v_norm_new = scaled_sq_sum.sum(dim=(-2, -1), keepdim=True).sqrt()
+    final_scale = step_size * (v_norm / v_norm_new.clamp_min(1e-10))
+    g = g * final_scale.to(g.dtype)
     lr = lr_t.to(g.dtype)
     wd = wd_t.to(g.dtype)
     mask = (g * stacked_params) >= 0
@@ -1045,10 +1108,11 @@ class DistMuonAdamW(torch.optim.Optimizer):
             self._muon_beta2_t.fill_(group["beta2"])
             self._muon_lr_t.fill_(group["lr"] * max(1.0, shape[-2] / shape[-1])**0.5)
             self._muon_wd_t.fill_(group["weight_decay"])
-            muon_step_fused(info['grad_chunk'][:num_owned], owned,
-                          state["momentum_buffer"][:num_owned], state["second_momentum_buffer"][:num_owned],
-                          self._muon_momentum_t, self._muon_lr_t, self._muon_wd_t, self._muon_beta2_t,
-                          group["ns_steps"], red_dim)
+            muon_step = muon_step_fused_eqr if group.get("muon_eq_r", False) else muon_step_fused
+            muon_step(info['grad_chunk'][:num_owned], owned,
+                      state["momentum_buffer"][:num_owned], state["second_momentum_buffer"][:num_owned],
+                      self._muon_momentum_t, self._muon_lr_t, self._muon_wd_t, self._muon_beta2_t,
+                      group["ns_steps"], red_dim)
             updated[:num_owned].copy_(owned)
         if num_owned < chunk_size:
             updated[num_owned:].zero_()
@@ -1076,49 +1140,130 @@ class DistMuonAdamW(torch.optim.Optimizer):
 # =============================================================================
 
 class DataLoader:
-    """Pre-tokenized dataloader. Yields (inputs, targets, epoch) forever."""
+    """Pre-tokenized dataloader. Supports flat-token and legacy chunked datasets."""
 
-    def __init__(self, filepath, B, T, device="cuda"):
+    def __init__(self, filepath, B, T, device="cuda", doc_shuffle=False):
         data = torch.load(filepath, weights_only=True)
-        all_tokens = data["tokens"].long()
-        sequence_size = T + 1
+        chunked_keys = {"chunks", "valid_counts", "batch_size", "sequence_size"}
+        flat_keys = {"tokens", "doc_starts", "bos_id", "seq_shuffle_seed"}
 
-        # Reconstruct the old sequence ordering from flat tokens
-        num_seqs = len(all_tokens) // sequence_size
-        all_seqs = all_tokens[:num_seqs * sequence_size].view(num_seqs, sequence_size)
-        perm = np.random.RandomState(data["seq_shuffle_seed"]).permutation(num_seqs)
-        all_seqs = all_seqs[torch.from_numpy(perm)]  # (N, T+1)
-
-        # DDP sharding: each rank gets every world_size-th batch
         _, rank, _, world_size = get_dist_info()
-        seqs_per_step = B * world_size
-        num_steps = len(all_seqs) // seqs_per_step
-        usable = num_steps * seqs_per_step
-        all_seqs = all_seqs[:usable].view(num_steps, world_size, B, sequence_size)
-
-        self.rank_data = all_seqs[:, rank].contiguous()  # (num_steps, B, T+1)
-        self.num_steps = num_steps
-        self.total_tokens = usable * T  # trainable tokens across all ranks
+        self.rank = rank
+        self.world_size = world_size
         self.device = device
+        self.B = B
+        self.T = T
+        self.seq_size = T + 1
         self.pos = 0
         self.epoch = 1
+        self.data_format = "chunked"
+        self.doc_shuffle = False
+
+        if chunked_keys.issubset(data):
+            chunks = data["chunks"]
+            valid_counts = data["valid_counts"]
+            file_B = data["batch_size"]
+            sequence_size = data["sequence_size"]
+            assert sequence_size == self.seq_size, f"Data sequence_size {sequence_size} != T+1={T+1}"
+
+            all_seqs = []
+            for chunk, vc in zip(chunks, valid_counts):
+                rows = chunk.view(file_B, sequence_size)[:vc]
+                all_seqs.append(rows)
+            self.all_seqs = torch.cat(all_seqs, dim=0).long()
+            if doc_shuffle:
+                print0(
+                    f"Warning: {filepath} is a legacy chunked dataset; "
+                    "document shuffling is unavailable until the data is regenerated with prepare_data.py."
+                )
+            self._build_chunked_rank_data()
+            return
+
+        if not flat_keys.issubset(data):
+            found_keys = ", ".join(sorted(data.keys()))
+            raise ValueError(
+                f"{filepath} is not a recognized dataset format. "
+                f"Expected flat keys {sorted(flat_keys)} or chunked keys {sorted(chunked_keys)}, found [{found_keys}]."
+            )
+
+        if "seq_size" in data:
+            assert int(data["seq_size"]) == self.seq_size, f"Data seq_size {int(data['seq_size'])} != T+1={T+1}"
+        bos_id = int(data["bos_id"])
+        assert bos_id == BOS_ID, f"data bos_id {bos_id} != expected {BOS_ID}"
+
+        all_tokens = data["tokens"].long()
+        raw_doc_starts = data["doc_starts"].long()
+        doc_ends = torch.cat([raw_doc_starts[1:], torch.tensor([all_tokens.numel()])])
+        self.base_doc_tokens = [all_tokens[s:e] for s, e in zip(raw_doc_starts.tolist(), doc_ends.tolist())]
+        self.default_shuffle_seed = int(data["seq_shuffle_seed"])
+        self.data_format = "flat"
+        self.doc_shuffle = doc_shuffle
+        self._build_flat_rank_data()
+
+    def _build_chunked_rank_data(self):
+        seqs_per_step = self.B * self.world_size
+        num_steps = len(self.all_seqs) // seqs_per_step
+        usable = num_steps * seqs_per_step
+        all_seqs = self.all_seqs[:usable].view(num_steps, self.world_size, self.B, self.seq_size)
+        self.rank_data = all_seqs[:, self.rank].contiguous()
+        self.num_steps = num_steps
+        self.total_tokens = usable * self.T
+        self.pos = 0
+
+    def _build_flat_rank_data(self):
+        doc_tokens = self.base_doc_tokens
+        if self.doc_shuffle:
+            g = torch.Generator()
+            g.manual_seed(self.epoch)
+            perm = torch.randperm(len(self.base_doc_tokens), generator=g)
+            doc_tokens = [self.base_doc_tokens[i] for i in perm.tolist()]
+
+        tokens = torch.cat(doc_tokens)
+        num_seqs = len(tokens) // self.seq_size
+        all_seqs = tokens[:num_seqs * self.seq_size].view(num_seqs, self.seq_size)
+        if self.doc_shuffle:
+            g = torch.Generator()
+            g.manual_seed(self.epoch + 1000)
+            all_seqs = all_seqs[torch.randperm(num_seqs, generator=g)]
+        else:
+            perm = np.random.RandomState(self.default_shuffle_seed).permutation(num_seqs)
+            all_seqs = all_seqs[torch.from_numpy(perm)]
+
+        seqs_per_step = self.B * self.world_size
+        num_steps = len(all_seqs) // seqs_per_step
+        usable = num_steps * seqs_per_step
+        all_seqs = all_seqs[:usable].view(num_steps, self.world_size, self.B, self.seq_size)
+        self.rank_data = all_seqs[:, self.rank].contiguous()
+        self.num_steps = num_steps
+        self.total_tokens = usable * self.T
+        self.pos = 0
 
     def __iter__(self):
         return self
 
-    def _shuffle(self):
-        """Shuffle batch order for the new epoch, consistent across ranks."""
+    def _shuffle_chunked(self):
         g = torch.Generator()
         g.manual_seed(self.epoch)
         perm = torch.randperm(self.num_steps, generator=g)
         self.rank_data = self.rank_data[perm]
 
+    def _next_epoch(self):
+        self.epoch += 1
+        print0(f"Starting epoch {self.epoch}")
+        self.pos = 0
+        if self.data_format == "flat":
+            if self.doc_shuffle:
+                self._build_flat_rank_data()
+            else:
+                g = torch.Generator()
+                g.manual_seed(self.epoch)
+                self.rank_data = self.rank_data[torch.randperm(self.num_steps, generator=g)]
+        else:
+            self._shuffle_chunked()
+
     def __next__(self):
         if self.pos >= self.num_steps:
-            self.pos = 0
-            self.epoch += 1
-            print0(f"Starting epoch {self.epoch}")
-            self._shuffle()
+            self._next_epoch()
         batch = self.rank_data[self.pos].to(self.device, non_blocking=True)
         self.pos += 1
         return batch[:, :-1].contiguous(), batch[:, 1:].contiguous(), self.epoch
@@ -1212,7 +1357,10 @@ print0(f"  matrix_lr={MATRIX_LR}, scalar_lr={SCALAR_LR}, embedding_lr={EMBEDDING
 print0(f"  weight_decay={WEIGHT_DECAY}, adam_betas={ADAM_BETAS}")
 print0(f"  warmup_ratio={WARMUP_RATIO}, warmdown_ratio={WARMDOWN_RATIO}, final_lr_frac={FINAL_LR_FRAC}")
 print0(f"  num_epochs={args.num_epochs}, patience={args.patience}")
-print0(f"  dropout={args.dropout}")
+print0(f"  dropout={args.dropout}, doc_shuffle={not args.no_doc_shuffle}")
+print0(f"  grad_clip={args.grad_clip}")
+print0(f"  muon_eq_r={args.muon_eq_r}")
+print0(f"  muon_ns_schedule={args.muon_ns_schedule}")
 print0(f"  linear_attn_type={args.linear_attn_type}")
 print0(f"  gdn_no_conv={args.gdn_no_conv}, gdn_use_recurrent={args.gdn_use_recurrent}, gdn_profile={args.gdn_profile}")
 print0(f"-----------------------")
@@ -1332,7 +1480,7 @@ optimizer = model.setup_optimizer()
 # Dataloaders
 _train_path = args.input_bin if args.input_bin else os.path.join(DATA_DIR, "fineweb_train.pt")
 _val_path = args.input_val_bin if args.input_val_bin else os.path.join(DATA_DIR, "fineweb_val.pt")
-train_loader = DataLoader(_train_path, args.device_batch_size, MAX_SEQ_LEN, device=device)
+train_loader = DataLoader(_train_path, args.device_batch_size, MAX_SEQ_LEN, device=device, doc_shuffle=not args.no_doc_shuffle)
 build_val_loader = lambda: DataLoader(_val_path, args.device_batch_size, MAX_SEQ_LEN, device=device)
 TOKENS_PER_EPOCH = train_loader.total_tokens
 x, y, current_epoch = next(train_loader)
@@ -1415,6 +1563,9 @@ while current_epoch <= args.num_epochs:
         x, y, epoch = next(train_loader)
 
     # Update optimizer
+    grad_norm = None
+    if args.grad_clip > 0:
+        grad_norm = torch.nn.utils.clip_grad_norm_(orig_model.parameters(), args.grad_clip)
     lrm = get_lr_multiplier(step)
     for group in optimizer.param_groups:
         group["lr"] = group["initial_lr"] * lrm
@@ -1451,7 +1602,10 @@ while current_epoch <= args.num_epochs:
     eta_str = f" | eta: {(num_iterations - step) * total_training_time / timed_steps / 60:.1f}m" if timed_steps > 0 else ""
     dupe_str = " [DUPE]" if dupe_active else ""
     print0(f"step {step:05d} ({pct:.2f}%) | loss: {debiased:.6f} | dt: {dt*1000:.2f}ms | tok/sec: {tok_per_sec:,} | bf16_mfu: {mfu:.2f}%{dupe_str}{eta_str}")
-    wandb_run.log({"step": step, "train/loss": debiased, "train/mfu": mfu})
+    log_dict = {"step": step, "train/loss": debiased, "train/mfu": mfu}
+    if grad_norm is not None:
+        log_dict["train/grad_norm"] = grad_norm.item()
+    wandb_run.log(log_dict)
 
     # Synchronize epoch across ranks (different ranks may exhaust data at different steps)
     if ddp:
@@ -1567,6 +1721,9 @@ if args.save_result and master_process:
         "matrix_lr": args.matrix_lr,
         "weight_decay": args.weight_decay,
         "num_epochs": args.num_epochs,
+        "grad_clip": args.grad_clip,
+        "muon_eq_r": args.muon_eq_r,
+        "muon_ns_schedule": args.muon_ns_schedule,
         "input_bin": _train_path,
         "input_val_bin": _val_path,
         "val_loss": val_loss,

--- a/tiny/train.py
+++ b/tiny/train.py
@@ -8,7 +8,7 @@ Usage:
 """
 
 import os
-os.environ["PYTORCH_ALLOC_CONF"] = "expandable_segments:True"
+os.environ["PYTORCH_ALLOC_CONF"] = "expandable_segments:True"a
 import gc
 import math
 import time
@@ -68,10 +68,6 @@ parser.add_argument("--input_val_bin", type=str, default=None)
 parser.add_argument("--output_json", type=str, default=None)
 parser.add_argument("--wandb_group", type=str, default=None)
 parser.add_argument("--dropout", type=float, default=0.1)
-parser.add_argument("--muon-eq-r", action="store_true", dest="muon_eq_r", default=True,
-                    help="Enable MuonEq-R row normalization in the Muon path")
-parser.add_argument("--no-muon-eq-r", action="store_false", dest="muon_eq_r",
-                    help="Disable MuonEq-R row normalization in the Muon path")
 parser.add_argument("--update-ema-every", type=int, default=10)
 parser.add_argument("--ema-decay-per-epoch", type=float, default=0.15)
 parser.add_argument("--swa-last-epochs", type=int, default=4,
@@ -427,8 +423,7 @@ class GPT(nn.Module):
         for shape in sorted({p.shape for p in matrix_params}):
             group_params = [p for p in matrix_params if p.shape == shape]
             param_groups.append(dict(kind='muon', params=group_params, lr=MATRIX_LR,
-                                     momentum=0.95, ns_steps=5, beta2=0.95,
-                                     weight_decay=WEIGHT_DECAY, muon_eq_r=args.muon_eq_r))
+                                     momentum=0.95, ns_steps=5, beta2=0.95, weight_decay=WEIGHT_DECAY))
 
         optimizer = DistMuonAdamW(param_groups)
         for group in optimizer.param_groups:
@@ -485,44 +480,6 @@ def muon_step_fused(stacked_grads, stacked_params, momentum_buffer, second_momen
     momentum = momentum_t.to(stacked_grads.dtype)
     momentum_buffer.lerp_(stacked_grads, 1 - momentum)
     g = stacked_grads.lerp_(momentum_buffer, momentum)
-    # Polar Express orthogonalization
-    X = g.bfloat16()
-    X = X / (X.norm(dim=(-2, -1), keepdim=True) * 1.02 + 1e-6)
-    if g.size(-2) > g.size(-1):
-        for a, b, c in polar_express_coeffs[:ns_steps]:
-            A = X.mT @ X
-            X = a * X + X @ (b * A + c * (A @ A))
-    else:
-        for a, b, c in polar_express_coeffs[:ns_steps]:
-            A = X @ X.mT
-            X = a * X + (b * A + c * (A @ A)) @ X
-    g = X
-    # Variance reduction
-    beta2 = beta2_t.to(g.dtype)
-    v_mean = g.float().square().mean(dim=red_dim, keepdim=True)
-    red_dim_size = g.size(red_dim)
-    v_norm_sq = v_mean.sum(dim=(-2, -1), keepdim=True) * red_dim_size
-    v_norm = v_norm_sq.sqrt()
-    second_momentum_buffer.lerp_(v_mean.to(dtype=second_momentum_buffer.dtype), 1 - beta2)
-    step_size = second_momentum_buffer.clamp_min(1e-10).rsqrt()
-    scaled_sq_sum = (v_mean * red_dim_size) * step_size.float().square()
-    v_norm_new = scaled_sq_sum.sum(dim=(-2, -1), keepdim=True).sqrt()
-    final_scale = step_size * (v_norm / v_norm_new.clamp_min(1e-10))
-    g = g * final_scale.to(g.dtype)
-    # Cautious weight decay + update
-    lr = lr_t.to(g.dtype)
-    wd = wd_t.to(g.dtype)
-    mask = (g * stacked_params) >= 0
-    stacked_params.sub_(lr * g + lr * wd * stacked_params * mask)
-
-@torch.compile(dynamic=False, fullgraph=True)
-def muon_step_fused_eqr(stacked_grads, stacked_params, momentum_buffer, second_momentum_buffer,
-                        momentum_t, lr_t, wd_t, beta2_t, ns_steps, red_dim):
-    momentum = momentum_t.to(stacked_grads.dtype)
-    momentum_buffer.lerp_(stacked_grads, 1 - momentum)
-    g = stacked_grads.lerp_(momentum_buffer, momentum)
-    # MuonEq-R row normalization
-    g /= g.float().norm(dim=-1, keepdim=True).clamp_min(1e-7).to(g.dtype)
     # Polar Express orthogonalization
     X = g.bfloat16()
     X = X / (X.norm(dim=(-2, -1), keepdim=True) * 1.02 + 1e-6)
@@ -648,11 +605,10 @@ class DistMuonAdamW(torch.optim.Optimizer):
             self._muon_beta2_t.fill_(group["beta2"])
             self._muon_lr_t.fill_(group["lr"] * max(1.0, shape[-2] / shape[-1])**0.5)
             self._muon_wd_t.fill_(group["weight_decay"])
-            muon_step = muon_step_fused_eqr if group.get("muon_eq_r", False) else muon_step_fused
-            muon_step(info['grad_chunk'][:num_owned], owned,
-                      state["momentum_buffer"][:num_owned], state["second_momentum_buffer"][:num_owned],
-                      self._muon_momentum_t, self._muon_lr_t, self._muon_wd_t, self._muon_beta2_t,
-                      group["ns_steps"], red_dim)
+            muon_step_fused(info['grad_chunk'][:num_owned], owned,
+                          state["momentum_buffer"][:num_owned], state["second_momentum_buffer"][:num_owned],
+                          self._muon_momentum_t, self._muon_lr_t, self._muon_wd_t, self._muon_beta2_t,
+                          group["ns_steps"], red_dim)
             updated[:num_owned].copy_(owned)
         if num_owned < chunk_size:
             updated[num_owned:].zero_()
@@ -862,7 +818,6 @@ if master_process:
 print0(f"--- Hyperparameters ---")
 print0(f"  n_layer={DEPTH}, n_embd={N_EMBD}, n_head={N_HEAD}, head_dim={HEAD_DIM}")
 print0(f"  seq_len={MAX_SEQ_LEN}, window_pattern={WINDOW_PATTERN}")
-print0(f"  muon_eq_r={args.muon_eq_r}")
 print0(f"  total_batch_size={TOTAL_BATCH_SIZE}, device_batch_size={args.device_batch_size}")
 print0(f"  matrix_lr={MATRIX_LR}, scalar_lr={SCALAR_LR}, embedding_lr={EMBEDDING_LR}, unembedding_lr={UNEMBEDDING_LR}")
 print0(f"  weight_decay={WEIGHT_DECAY}, adam_betas={ADAM_BETAS}")
@@ -1131,7 +1086,6 @@ if master_process:
         "matrix_lr": args.matrix_lr,
         "weight_decay": args.weight_decay,
         "num_epochs": args.num_epochs,
-        "muon_eq_r": args.muon_eq_r,
         "val_loss": val_loss,
         "best_val_loss": min_val_loss,
         "wandb_url": getattr(wandb_run, "url", None),

--- a/tiny/train.py
+++ b/tiny/train.py
@@ -65,13 +65,6 @@ parser.add_argument("--input_val_bin", type=str, default=None)
 parser.add_argument("--output_json", type=str, default=None)
 parser.add_argument("--wandb_group", type=str, default=None)
 parser.add_argument("--dropout", type=float, default=0.1)
-parser.add_argument("--seed", type=int, default=42)
-parser.add_argument("--iha", action="store_true", default=True,
-                    help="Enable Interleaved Head Attention (cross-head Q/K/V mixing)")
-parser.add_argument("--no-iha", action="store_false", dest="iha",
-                    help="Disable IHA cross-head mixing")
-parser.add_argument("--iha-lr", type=float, default=0.02,
-                    help="LR for IHA mixing matrices")
 parser.add_argument("--muon-eq-r", action="store_true", dest="muon_eq_r", default=True,
                     help="Enable MuonEq-R row normalization in the Muon path")
 parser.add_argument("--no-muon-eq-r", action="store_false", dest="muon_eq_r",
@@ -200,8 +193,6 @@ class GPTConfig:
     n_embd: int = N_EMBD
     window_pattern: str = WINDOW_PATTERN
     dropout: float = 0.1
-    use_iha: bool = False
-    iha_mix_v: bool = True
 
 def norm(x):
     return F.rms_norm(x, (x.size(-1),))
@@ -234,39 +225,16 @@ class CausalSelfAttention(nn.Module):
         # Per-head attention gate: enables context-based attention no-op
         self.attn_gate_channels = 12
         self.attn_gate = nn.Linear(self.attn_gate_channels, self.n_head, bias=False)
-        # IHA: cross-head mixing matrices fused into projection weights at forward time.
-        self.use_iha = config.use_iha
-        if self.use_iha:
-            self.q_mix = nn.Parameter(torch.zeros(self.n_head, self.n_head))
-            self.k_mix = nn.Parameter(torch.zeros(self.n_kv_head, self.n_kv_head))
-            self.iha_mix_v = config.iha_mix_v
-            if self.iha_mix_v:
-                self.v_mix = nn.Parameter(torch.zeros(self.n_kv_head, self.n_kv_head))
         # Determine if this is a long-window layer for partial key offset
         pattern = config.window_pattern.upper()
         char = pattern[layer_idx % len(pattern)]
         self.use_key_offset = (char == 'L') or (layer_idx == config.n_layer - 1)
 
-    def _fuse_mix(self, weight, mix, H):
-        d = self.head_dim
-        return (mix @ weight.view(H, d, -1).flatten(1)).view_as(weight)
-
     def forward(self, x, ve, cos_sin, window_size):
         B, T, C = x.size()
-        if self.use_iha:
-            q = F.linear(x, self._fuse_mix(self.c_q.weight, self.q_mix, self.n_head))
-            q = q.view(B, T, self.n_head, self.head_dim)
-            k = F.linear(x, self._fuse_mix(self.c_k.weight, self.k_mix, self.n_kv_head))
-            k = k.view(B, T, self.n_kv_head, self.head_dim)
-            if self.iha_mix_v:
-                v = F.linear(x, self._fuse_mix(self.c_v.weight, self.v_mix, self.n_kv_head))
-                v = v.view(B, T, self.n_kv_head, self.head_dim)
-            else:
-                v = self.c_v(x).view(B, T, self.n_kv_head, self.head_dim)
-        else:
-            q = self.c_q(x).view(B, T, self.n_head, self.head_dim)
-            k = self.c_k(x).view(B, T, self.n_kv_head, self.head_dim)
-            v = self.c_v(x).view(B, T, self.n_kv_head, self.head_dim)
+        q = self.c_q(x).view(B, T, self.n_head, self.head_dim)
+        k = self.c_k(x).view(B, T, self.n_kv_head, self.head_dim)
+        v = self.c_v(x).view(B, T, self.n_kv_head, self.head_dim)
         # Value residual (ResFormer)
         if ve is not None:
             ve = ve.view(B, T, self.n_kv_head, self.head_dim)
@@ -348,11 +316,6 @@ class GPT(nn.Module):
             torch.nn.init.uniform_(block.mlp.c_gate.weight, -s, s)
             torch.nn.init.uniform_(block.mlp.c_fc.weight, -s, s)
             torch.nn.init.zeros_(block.mlp.c_proj.weight)
-            if block.attn.use_iha:
-                torch.nn.init.eye_(block.attn.q_mix)
-                torch.nn.init.eye_(block.attn.k_mix)
-                if block.attn.iha_mix_v:
-                    torch.nn.init.eye_(block.attn.v_mix)
 
         self.resid_lambdas.fill_(1.1)
         self.x0_lambdas.fill_(0.1)
@@ -412,20 +375,11 @@ class GPT(nn.Module):
 
     def setup_optimizer(self):
         ddp, rank, local_rank, world_size = get_dist_info()
-        # Separate attn_gate + IHA mixing params (small, Adam-optimized) from matrix params (Muon)
+        # Separate attn_gate params (small, Adam-optimized) from matrix params (Muon)
         attn_gate_params = [block.attn.attn_gate.weight for block in self.transformer.h]
-        special_ids = {id(p) for p in attn_gate_params}
-        iha_params = []
-        for block in self.transformer.h:
-            if block.attn.use_iha:
-                iha_params.extend([block.attn.q_mix, block.attn.k_mix])
-                special_ids.add(id(block.attn.q_mix))
-                special_ids.add(id(block.attn.k_mix))
-                if block.attn.iha_mix_v:
-                    iha_params.append(block.attn.v_mix)
-                    special_ids.add(id(block.attn.v_mix))
+        attn_gate_ids = {id(p) for p in attn_gate_params}
         all_h_params = list(self.transformer.h.parameters()) + list(self.ve_projs.parameters())
-        matrix_params = [p for p in all_h_params if id(p) not in special_ids]
+        matrix_params = [p for p in all_h_params if id(p) not in attn_gate_ids]
         embed_params = list(self.transformer.wte.parameters())
         lm_head_params = list(self.lm_head.parameters())
         resid_params = [self.resid_lambdas]
@@ -440,9 +394,6 @@ class GPT(nn.Module):
             dict(kind='adamw', params=skip_params, lr=SCALAR_LR * 0.01, betas=ADAM_BETAS, eps=1e-10, weight_decay=0.0),
             dict(kind='adamw', params=attn_gate_params, lr=SCALAR_LR, betas=(0.9, 0.99), eps=1e-10, weight_decay=0.0),
         ]
-        if iha_params:
-            param_groups.append(dict(kind='adamw', params=iha_params, lr=args.iha_lr,
-                                     betas=ADAM_BETAS, eps=1e-10, weight_decay=0.0))
         for shape in sorted({p.shape for p in matrix_params}):
             group_params = [p for p in matrix_params if p.shape == shape]
             param_groups.append(dict(kind='muon', params=group_params, lr=MATRIX_LR,
@@ -701,7 +652,7 @@ class DistMuonAdamW(torch.optim.Optimizer):
 class DataLoader:
     """Pre-tokenized chunk dataloader. Yields (inputs, targets, epoch) forever."""
 
-    def __init__(self, filepath, B, T, device="cuda", seed=42):
+    def __init__(self, filepath, B, T, device="cuda"):
         data = torch.load(filepath, weights_only=True)
         chunks = data['chunks']
         valid_counts = data['valid_counts']
@@ -727,7 +678,6 @@ class DataLoader:
         self.num_steps = num_steps
         self.total_tokens = usable * T  # trainable tokens across all ranks
         self.device = device
-        self.seed = seed
         self.pos = 0
         self.epoch = 1
 
@@ -737,7 +687,7 @@ class DataLoader:
     def _shuffle(self):
         """Shuffle batch order for the new epoch, consistent across ranks."""
         g = torch.Generator()
-        g.manual_seed(self.seed + self.epoch)
+        g.manual_seed(self.epoch)
         perm = torch.randperm(self.num_steps, generator=g)
         self.rank_data = self.rank_data[perm]
 
@@ -791,12 +741,12 @@ def evaluate_bpb(model, batches, steps, token_bytes):
 # Compute init
 ddp, ddp_rank, ddp_local_rank, ddp_world_size = get_dist_info()
 master_process = ddp_rank == 0
-torch.manual_seed(args.seed)
+torch.manual_seed(42)
 
 if ddp and torch.cuda.is_available():
     device = torch.device("cuda", ddp_local_rank)
     torch.cuda.set_device(device)
-    torch.cuda.manual_seed(args.seed)
+    torch.cuda.manual_seed(42)
     dist.init_process_group(backend="nccl", device_id=device)
     dist.barrier()
 else:
@@ -834,7 +784,6 @@ if master_process:
 print0(f"--- Hyperparameters ---")
 print0(f"  n_layer={DEPTH}, n_embd={N_EMBD}, n_head={N_HEAD}, head_dim={HEAD_DIM}")
 print0(f"  seq_len={MAX_SEQ_LEN}, window_pattern={WINDOW_PATTERN}")
-print0(f"  iha={args.iha}, iha_lr={args.iha_lr}")
 print0(f"  muon_eq_r={args.muon_eq_r}")
 print0(f"  total_batch_size={TOTAL_BATCH_SIZE}, device_batch_size={args.device_batch_size}")
 print0(f"  matrix_lr={MATRIX_LR}, scalar_lr={SCALAR_LR}, embedding_lr={EMBEDDING_LR}, unembedding_lr={UNEMBEDDING_LR}")
@@ -842,7 +791,6 @@ print0(f"  weight_decay={WEIGHT_DECAY}, adam_betas={ADAM_BETAS}")
 print0(f"  warmup_ratio={WARMUP_RATIO}, warmdown_ratio={WARMDOWN_RATIO}, final_lr_frac={FINAL_LR_FRAC}")
 print0(f"  num_epochs={args.num_epochs}, patience={args.patience}")
 print0(f"  dropout={args.dropout}")
-print0(f"  seed={args.seed}")
 print0(f"-----------------------")
 
 # Load GPT-2 tokenizer and compute token_bytes for BPB evaluation
@@ -860,7 +808,7 @@ for i in range(vocab_size):
 token_bytes = torch.tensor(token_bytes_list, dtype=torch.int32, device=device)
 
 # Build model
-config = GPTConfig(vocab_size=vocab_size, dropout=args.dropout, use_iha=args.iha)
+config = GPTConfig(vocab_size=vocab_size, dropout=args.dropout)
 with torch.device("meta"):
     model = GPT(config)
 model.to_empty(device=device)
@@ -885,8 +833,8 @@ optimizer = model.setup_optimizer()
 # Dataloaders
 _train_path = args.input_bin if args.input_bin else os.path.join(DATA_DIR, "fineweb_train.pt")
 _val_path = args.input_val_bin if args.input_val_bin else os.path.join(DATA_DIR, "fineweb_val.pt")
-train_loader = DataLoader(_train_path, args.device_batch_size, MAX_SEQ_LEN, device=device, seed=args.seed)
-build_val_loader = lambda: DataLoader(_val_path, args.device_batch_size, MAX_SEQ_LEN, device=device, seed=args.seed)
+train_loader = DataLoader(_train_path, args.device_batch_size, MAX_SEQ_LEN, device=device)
+build_val_loader = lambda: DataLoader(_val_path, args.device_batch_size, MAX_SEQ_LEN, device=device)
 TOKENS_PER_EPOCH = train_loader.total_tokens
 x, y, current_epoch = next(train_loader)
 

--- a/tiny/train.py
+++ b/tiny/train.py
@@ -65,6 +65,17 @@ parser.add_argument("--input_val_bin", type=str, default=None)
 parser.add_argument("--output_json", type=str, default=None)
 parser.add_argument("--wandb_group", type=str, default=None)
 parser.add_argument("--dropout", type=float, default=0.1)
+parser.add_argument("--seed", type=int, default=42)
+parser.add_argument("--iha", action="store_true", default=True,
+                    help="Enable Interleaved Head Attention (cross-head Q/K/V mixing)")
+parser.add_argument("--no-iha", action="store_false", dest="iha",
+                    help="Disable IHA cross-head mixing")
+parser.add_argument("--iha-lr", type=float, default=0.02,
+                    help="LR for IHA mixing matrices")
+parser.add_argument("--muon-eq-r", action="store_true", dest="muon_eq_r", default=True,
+                    help="Enable MuonEq-R row normalization in the Muon path")
+parser.add_argument("--no-muon-eq-r", action="store_false", dest="muon_eq_r",
+                    help="Disable MuonEq-R row normalization in the Muon path")
 parser.add_argument("--update-ema-every", type=int, default=10)
 parser.add_argument("--ema-decay-per-epoch", type=float, default=0.15)
 parser.add_argument("--swa-last-epochs", type=int, default=4,
@@ -189,6 +200,8 @@ class GPTConfig:
     n_embd: int = N_EMBD
     window_pattern: str = WINDOW_PATTERN
     dropout: float = 0.1
+    use_iha: bool = False
+    iha_mix_v: bool = True
 
 def norm(x):
     return F.rms_norm(x, (x.size(-1),))
@@ -221,16 +234,39 @@ class CausalSelfAttention(nn.Module):
         # Per-head attention gate: enables context-based attention no-op
         self.attn_gate_channels = 12
         self.attn_gate = nn.Linear(self.attn_gate_channels, self.n_head, bias=False)
+        # IHA: cross-head mixing matrices fused into projection weights at forward time.
+        self.use_iha = config.use_iha
+        if self.use_iha:
+            self.q_mix = nn.Parameter(torch.zeros(self.n_head, self.n_head))
+            self.k_mix = nn.Parameter(torch.zeros(self.n_kv_head, self.n_kv_head))
+            self.iha_mix_v = config.iha_mix_v
+            if self.iha_mix_v:
+                self.v_mix = nn.Parameter(torch.zeros(self.n_kv_head, self.n_kv_head))
         # Determine if this is a long-window layer for partial key offset
         pattern = config.window_pattern.upper()
         char = pattern[layer_idx % len(pattern)]
         self.use_key_offset = (char == 'L') or (layer_idx == config.n_layer - 1)
 
+    def _fuse_mix(self, weight, mix, H):
+        d = self.head_dim
+        return (mix @ weight.view(H, d, -1).flatten(1)).view_as(weight)
+
     def forward(self, x, ve, cos_sin, window_size):
         B, T, C = x.size()
-        q = self.c_q(x).view(B, T, self.n_head, self.head_dim)
-        k = self.c_k(x).view(B, T, self.n_kv_head, self.head_dim)
-        v = self.c_v(x).view(B, T, self.n_kv_head, self.head_dim)
+        if self.use_iha:
+            q = F.linear(x, self._fuse_mix(self.c_q.weight, self.q_mix, self.n_head))
+            q = q.view(B, T, self.n_head, self.head_dim)
+            k = F.linear(x, self._fuse_mix(self.c_k.weight, self.k_mix, self.n_kv_head))
+            k = k.view(B, T, self.n_kv_head, self.head_dim)
+            if self.iha_mix_v:
+                v = F.linear(x, self._fuse_mix(self.c_v.weight, self.v_mix, self.n_kv_head))
+                v = v.view(B, T, self.n_kv_head, self.head_dim)
+            else:
+                v = self.c_v(x).view(B, T, self.n_kv_head, self.head_dim)
+        else:
+            q = self.c_q(x).view(B, T, self.n_head, self.head_dim)
+            k = self.c_k(x).view(B, T, self.n_kv_head, self.head_dim)
+            v = self.c_v(x).view(B, T, self.n_kv_head, self.head_dim)
         # Value residual (ResFormer)
         if ve is not None:
             ve = ve.view(B, T, self.n_kv_head, self.head_dim)
@@ -312,6 +348,11 @@ class GPT(nn.Module):
             torch.nn.init.uniform_(block.mlp.c_gate.weight, -s, s)
             torch.nn.init.uniform_(block.mlp.c_fc.weight, -s, s)
             torch.nn.init.zeros_(block.mlp.c_proj.weight)
+            if block.attn.use_iha:
+                torch.nn.init.eye_(block.attn.q_mix)
+                torch.nn.init.eye_(block.attn.k_mix)
+                if block.attn.iha_mix_v:
+                    torch.nn.init.eye_(block.attn.v_mix)
 
         self.resid_lambdas.fill_(1.1)
         self.x0_lambdas.fill_(0.1)
@@ -371,11 +412,20 @@ class GPT(nn.Module):
 
     def setup_optimizer(self):
         ddp, rank, local_rank, world_size = get_dist_info()
-        # Separate attn_gate params (small, Adam-optimized) from matrix params (Muon)
+        # Separate attn_gate + IHA mixing params (small, Adam-optimized) from matrix params (Muon)
         attn_gate_params = [block.attn.attn_gate.weight for block in self.transformer.h]
-        attn_gate_ids = {id(p) for p in attn_gate_params}
+        special_ids = {id(p) for p in attn_gate_params}
+        iha_params = []
+        for block in self.transformer.h:
+            if block.attn.use_iha:
+                iha_params.extend([block.attn.q_mix, block.attn.k_mix])
+                special_ids.add(id(block.attn.q_mix))
+                special_ids.add(id(block.attn.k_mix))
+                if block.attn.iha_mix_v:
+                    iha_params.append(block.attn.v_mix)
+                    special_ids.add(id(block.attn.v_mix))
         all_h_params = list(self.transformer.h.parameters()) + list(self.ve_projs.parameters())
-        matrix_params = [p for p in all_h_params if id(p) not in attn_gate_ids]
+        matrix_params = [p for p in all_h_params if id(p) not in special_ids]
         embed_params = list(self.transformer.wte.parameters())
         lm_head_params = list(self.lm_head.parameters())
         resid_params = [self.resid_lambdas]
@@ -390,10 +440,14 @@ class GPT(nn.Module):
             dict(kind='adamw', params=skip_params, lr=SCALAR_LR * 0.01, betas=ADAM_BETAS, eps=1e-10, weight_decay=0.0),
             dict(kind='adamw', params=attn_gate_params, lr=SCALAR_LR, betas=(0.9, 0.99), eps=1e-10, weight_decay=0.0),
         ]
+        if iha_params:
+            param_groups.append(dict(kind='adamw', params=iha_params, lr=args.iha_lr,
+                                     betas=ADAM_BETAS, eps=1e-10, weight_decay=0.0))
         for shape in sorted({p.shape for p in matrix_params}):
             group_params = [p for p in matrix_params if p.shape == shape]
             param_groups.append(dict(kind='muon', params=group_params, lr=MATRIX_LR,
-                                     momentum=0.95, ns_steps=5, beta2=0.95, weight_decay=WEIGHT_DECAY))
+                                     momentum=0.95, ns_steps=5, beta2=0.95,
+                                     weight_decay=WEIGHT_DECAY, muon_eq_r=args.muon_eq_r))
 
         optimizer = DistMuonAdamW(param_groups)
         for group in optimizer.param_groups:
@@ -450,6 +504,44 @@ def muon_step_fused(stacked_grads, stacked_params, momentum_buffer, second_momen
     momentum = momentum_t.to(stacked_grads.dtype)
     momentum_buffer.lerp_(stacked_grads, 1 - momentum)
     g = stacked_grads.lerp_(momentum_buffer, momentum)
+    # Polar Express orthogonalization
+    X = g.bfloat16()
+    X = X / (X.norm(dim=(-2, -1), keepdim=True) * 1.02 + 1e-6)
+    if g.size(-2) > g.size(-1):
+        for a, b, c in polar_express_coeffs[:ns_steps]:
+            A = X.mT @ X
+            X = a * X + X @ (b * A + c * (A @ A))
+    else:
+        for a, b, c in polar_express_coeffs[:ns_steps]:
+            A = X @ X.mT
+            X = a * X + (b * A + c * (A @ A)) @ X
+    g = X
+    # Variance reduction
+    beta2 = beta2_t.to(g.dtype)
+    v_mean = g.float().square().mean(dim=red_dim, keepdim=True)
+    red_dim_size = g.size(red_dim)
+    v_norm_sq = v_mean.sum(dim=(-2, -1), keepdim=True) * red_dim_size
+    v_norm = v_norm_sq.sqrt()
+    second_momentum_buffer.lerp_(v_mean.to(dtype=second_momentum_buffer.dtype), 1 - beta2)
+    step_size = second_momentum_buffer.clamp_min(1e-10).rsqrt()
+    scaled_sq_sum = (v_mean * red_dim_size) * step_size.float().square()
+    v_norm_new = scaled_sq_sum.sum(dim=(-2, -1), keepdim=True).sqrt()
+    final_scale = step_size * (v_norm / v_norm_new.clamp_min(1e-10))
+    g = g * final_scale.to(g.dtype)
+    # Cautious weight decay + update
+    lr = lr_t.to(g.dtype)
+    wd = wd_t.to(g.dtype)
+    mask = (g * stacked_params) >= 0
+    stacked_params.sub_(lr * g + lr * wd * stacked_params * mask)
+
+@torch.compile(dynamic=False, fullgraph=True)
+def muon_step_fused_eqr(stacked_grads, stacked_params, momentum_buffer, second_momentum_buffer,
+                        momentum_t, lr_t, wd_t, beta2_t, ns_steps, red_dim):
+    momentum = momentum_t.to(stacked_grads.dtype)
+    momentum_buffer.lerp_(stacked_grads, 1 - momentum)
+    g = stacked_grads.lerp_(momentum_buffer, momentum)
+    # MuonEq-R row normalization
+    g /= g.float().norm(dim=-1, keepdim=True).clamp_min(1e-7).to(g.dtype)
     # Polar Express orthogonalization
     X = g.bfloat16()
     X = X / (X.norm(dim=(-2, -1), keepdim=True) * 1.02 + 1e-6)
@@ -575,10 +667,11 @@ class DistMuonAdamW(torch.optim.Optimizer):
             self._muon_beta2_t.fill_(group["beta2"])
             self._muon_lr_t.fill_(group["lr"] * max(1.0, shape[-2] / shape[-1])**0.5)
             self._muon_wd_t.fill_(group["weight_decay"])
-            muon_step_fused(info['grad_chunk'][:num_owned], owned,
-                          state["momentum_buffer"][:num_owned], state["second_momentum_buffer"][:num_owned],
-                          self._muon_momentum_t, self._muon_lr_t, self._muon_wd_t, self._muon_beta2_t,
-                          group["ns_steps"], red_dim)
+            muon_step = muon_step_fused_eqr if group.get("muon_eq_r", False) else muon_step_fused
+            muon_step(info['grad_chunk'][:num_owned], owned,
+                      state["momentum_buffer"][:num_owned], state["second_momentum_buffer"][:num_owned],
+                      self._muon_momentum_t, self._muon_lr_t, self._muon_wd_t, self._muon_beta2_t,
+                      group["ns_steps"], red_dim)
             updated[:num_owned].copy_(owned)
         if num_owned < chunk_size:
             updated[num_owned:].zero_()
@@ -608,7 +701,7 @@ class DistMuonAdamW(torch.optim.Optimizer):
 class DataLoader:
     """Pre-tokenized chunk dataloader. Yields (inputs, targets, epoch) forever."""
 
-    def __init__(self, filepath, B, T, device="cuda"):
+    def __init__(self, filepath, B, T, device="cuda", seed=42):
         data = torch.load(filepath, weights_only=True)
         chunks = data['chunks']
         valid_counts = data['valid_counts']
@@ -634,6 +727,7 @@ class DataLoader:
         self.num_steps = num_steps
         self.total_tokens = usable * T  # trainable tokens across all ranks
         self.device = device
+        self.seed = seed
         self.pos = 0
         self.epoch = 1
 
@@ -643,7 +737,7 @@ class DataLoader:
     def _shuffle(self):
         """Shuffle batch order for the new epoch, consistent across ranks."""
         g = torch.Generator()
-        g.manual_seed(self.epoch)
+        g.manual_seed(self.seed + self.epoch)
         perm = torch.randperm(self.num_steps, generator=g)
         self.rank_data = self.rank_data[perm]
 
@@ -697,12 +791,12 @@ def evaluate_bpb(model, batches, steps, token_bytes):
 # Compute init
 ddp, ddp_rank, ddp_local_rank, ddp_world_size = get_dist_info()
 master_process = ddp_rank == 0
-torch.manual_seed(42)
+torch.manual_seed(args.seed)
 
 if ddp and torch.cuda.is_available():
     device = torch.device("cuda", ddp_local_rank)
     torch.cuda.set_device(device)
-    torch.cuda.manual_seed(42)
+    torch.cuda.manual_seed(args.seed)
     dist.init_process_group(backend="nccl", device_id=device)
     dist.barrier()
 else:
@@ -740,12 +834,15 @@ if master_process:
 print0(f"--- Hyperparameters ---")
 print0(f"  n_layer={DEPTH}, n_embd={N_EMBD}, n_head={N_HEAD}, head_dim={HEAD_DIM}")
 print0(f"  seq_len={MAX_SEQ_LEN}, window_pattern={WINDOW_PATTERN}")
+print0(f"  iha={args.iha}, iha_lr={args.iha_lr}")
+print0(f"  muon_eq_r={args.muon_eq_r}")
 print0(f"  total_batch_size={TOTAL_BATCH_SIZE}, device_batch_size={args.device_batch_size}")
 print0(f"  matrix_lr={MATRIX_LR}, scalar_lr={SCALAR_LR}, embedding_lr={EMBEDDING_LR}, unembedding_lr={UNEMBEDDING_LR}")
 print0(f"  weight_decay={WEIGHT_DECAY}, adam_betas={ADAM_BETAS}")
 print0(f"  warmup_ratio={WARMUP_RATIO}, warmdown_ratio={WARMDOWN_RATIO}, final_lr_frac={FINAL_LR_FRAC}")
 print0(f"  num_epochs={args.num_epochs}, patience={args.patience}")
 print0(f"  dropout={args.dropout}")
+print0(f"  seed={args.seed}")
 print0(f"-----------------------")
 
 # Load GPT-2 tokenizer and compute token_bytes for BPB evaluation
@@ -763,7 +860,7 @@ for i in range(vocab_size):
 token_bytes = torch.tensor(token_bytes_list, dtype=torch.int32, device=device)
 
 # Build model
-config = GPTConfig(vocab_size=vocab_size, dropout=args.dropout)
+config = GPTConfig(vocab_size=vocab_size, dropout=args.dropout, use_iha=args.iha)
 with torch.device("meta"):
     model = GPT(config)
 model.to_empty(device=device)
@@ -788,8 +885,8 @@ optimizer = model.setup_optimizer()
 # Dataloaders
 _train_path = args.input_bin if args.input_bin else os.path.join(DATA_DIR, "fineweb_train.pt")
 _val_path = args.input_val_bin if args.input_val_bin else os.path.join(DATA_DIR, "fineweb_val.pt")
-train_loader = DataLoader(_train_path, args.device_batch_size, MAX_SEQ_LEN, device=device)
-build_val_loader = lambda: DataLoader(_val_path, args.device_batch_size, MAX_SEQ_LEN, device=device)
+train_loader = DataLoader(_train_path, args.device_batch_size, MAX_SEQ_LEN, device=device, seed=args.seed)
+build_val_loader = lambda: DataLoader(_val_path, args.device_batch_size, MAX_SEQ_LEN, device=device, seed=args.seed)
 TOKENS_PER_EPOCH = train_loader.total_tokens
 x, y, current_epoch = next(train_loader)
 
@@ -1006,6 +1103,7 @@ if args.save_result and master_process:
         "matrix_lr": args.matrix_lr,
         "weight_decay": args.weight_decay,
         "num_epochs": args.num_epochs,
+        "muon_eq_r": args.muon_eq_r,
         "val_loss": val_loss,
         "best_val_loss": min_val_loss,
         "wandb_url": getattr(wandb_run, "url", None),

--- a/tiny/train.py
+++ b/tiny/train.py
@@ -8,7 +8,7 @@ Usage:
 """
 
 import os
-os.environ["PYTORCH_ALLOC_CONF"] = "expandable_segments:True"a
+os.environ["PYTORCH_ALLOC_CONF"] = "expandable_segments:True"
 import gc
 import math
 import time


### PR DESCRIPTION


This branch now covers:

- selectable linear-attention backends via `--linear-attn-type {gdn,kda}`
- the current GDN speed path via `--gdn-no-conv`
- MuonEq-R in the hybrid trainer via `--muon-eq-r`
- selectable Muon Newton-Schulz schedules via `--muon-ns-schedule {polar-express,deepseek-v4}`
- flat-token document shuffling support with `--no-doc-shuffle` for controlled ablations
- optional global grad clipping via `--grad-clip`
- updated hybrid-attention documentation reflecting the current quality-best and speed-quality frontier

## Why

- full TileLang-backed GDN is now the best quality-cost default on this Hopper host
- KDA remains a useful quality reference point, but not the default
- `--gdn-no-conv` established a better speed-quality option than the older GDN baseline


