### PR TITLE
Hybrid Attention Square-GDN 

### DIFF
--- a/research/hybrid_attn/README.md
+++ b/research/hybrid_attn/README.md
@@ -9,16 +9,17 @@ On Hopper hosts, full GDN training should use:
 
 ```bash
 FLA_TILELANG=1
-````
+```
 
 ## Current Leaderboard
 
 | Rank | Backend     | Best / Final Val Loss | Training Time | Peak Memory    | Notes                                               |
 | ---- | ----------- | --------------------- | ------------- | -------------- | --------------------------------------------------- |
-| 1    | GDN         | `3.230877 / 3.243014` | `80.38` min   | `54820.06` MiB | Current quality-best baseline with `--muon-eq-r`    |
-| 2    | GDN no-conv | `3.234275 / 3.246534` | `71.93` min   | `53583.05` MiB | Current speed-quality frontier with `--gdn-no-conv` |
-| 3    | KDA         | `3.239565 / 3.255612` | `89.28` min   | `57735.46` MiB | Slower quality reference line                       |
+| 1    | GDN square  | `3.228005 / 3.239774` | `87.99` min   | `57417.80` MiB | Current quality-best run with `--gdn-head-dim-mode square --muon-eq-r` |
+| 2    | GDN         | `3.230877 / 3.243014` | `80.38` min   | `54820.06` MiB | Param-matched GDN quality baseline with `--muon-eq-r` |
+| 3    | GDN no-conv | `3.234275 / 3.246534` | `71.93` min   | `53583.05` MiB | Current speed-quality frontier with `--gdn-no-conv` |
 | 4    | GDN         | `3.234646 / 3.247445` | `80.37` min   | `54820.06` MiB | TileLang GDN control before MuonEq-R                |
+| 5    | KDA         | `3.239565 / 3.255612` | `89.28` min   | `57735.46` MiB | Slower quality reference line                       |
 
 ## Records
 
@@ -27,21 +28,23 @@ FLA_TILELANG=1
 | PR `#49` (`1f0fe74`)                  | `3.246` val loss                                    | about `81` minutes                     |
 | PR `#58` (`5cb9428`)                  | `3.241282` val loss                                 | `72.33` min training, `76.91` min wall |
 | KDA / FlashKDA extension              | `3.239565` best val loss, `3.255612` final val loss | `89.28` min training, `94.42` min wall |
-| Current GDN quality-best              | `3.230877` best val loss, `3.243014` final val loss | `80.38` min training                   |
+| Current square-GDN quality-best       | `3.228005` best val loss, `3.239774` final val loss | `87.99` min training, `93.73` min wall |
+| Current param-matched GDN quality-best| `3.230877` best val loss, `3.243014` final val loss | `80.38` min training                   |
 | Current GDN no-conv speed-quality run | `3.234275` best val loss, `3.246534` final val loss | `71.93` min training                   |
 
 ## Usage
 
-Current quality-best GDN default:
+Current quality-best square-GDN default:
 
 ```bash
 FLA_TILELANG=1 torchrun --standalone --nproc_per_node=8 research/hybrid_attn/train.py \
   --gdn-layers 1,3,5,6,8,10,11,13,15,16,18,20,22,23 \
   --linear-attn-type gdn \
+  --gdn-head-dim-mode square \
   --muon-eq-r
 ```
 
-Current faster GDN alternative:
+Current faster param-matched GDN alternative:
 
 ```bash
 FLA_TILELANG=1 torchrun --standalone --nproc_per_node=8 research/hybrid_attn/train.py \
@@ -71,6 +74,7 @@ FLA_FLASH_KDA=1 torchrun --standalone --nproc_per_node=8 research/hybrid_attn/tr
 ## Trainer Options
 
 * `--linear-attn-type {gdn,kda}` switches the linear-attention block used on the selected hybrid layers.
+* `--gdn-head-dim-mode {param-matched,square}` switches the GDN key width between `d_head/2` and `d_head`.
 * `--gdn-no-conv` disables the GDN short-convolution path and is the current best runtime-saving knob.
 * `--muon-eq-r` enables row-normalized Muon updates and is part of the current quality-best hybrid baseline.
 * `--muon-ns-schedule {polar-express,deepseek-v4}` switches the Muon Newton-Schulz coefficient table.
@@ -80,9 +84,9 @@ FLA_FLASH_KDA=1 torchrun --standalone --nproc_per_node=8 research/hybrid_attn/tr
 
 ## Practical Guidance
 
-Use the quality-best GDN run as the control for new quality-focused GDN follow-ups.
+Use the square-GDN quality-best run as the control for new quality-focused GDN follow-ups.
 
-Use the GDN no-conv variant when runtime matters more than the last `0.003-0.004` of validation loss.
+Use the GDN no-conv variant when runtime matters more than the last `0.005-0.006` of validation loss.
 
 Treat KDA as a reference backend, not the default deployment path on this host. KDA still gives a strong quality reference, but it is materially slower.
 
@@ -101,11 +105,13 @@ For Hopper GDN runs, prefer `FLA_TILELANG=1`. The older non-TileLang GDN path is
 
 3. KDA / FlashKDA: upgraded the recurrent memory from a single forget coefficient per head to a per-dimension forget mechanism. The theoretical effect is a more expressive state space, where one head can preserve different subspaces for different timescales instead of forcing the whole head to forget or retain together. That improved loss, but it also increased runtime.
 
-4. Current GDN quality-best: moved the GDN frontier onto the Hopper TileLang path and added `--muon-eq-r`, improving the best validation loss to `3.230877`.
+4. Current param-matched GDN quality-best: moved the GDN frontier onto the Hopper TileLang path and added `--muon-eq-r`, improving the best validation loss to `3.230877`.
 
 5. Current GDN no-conv speed-quality run: disabled the GDN short-convolution path with `--gdn-no-conv`, giving the current speed-quality frontier. It is faster than the quality-best GDN run while giving up only a small amount of validation loss.
 
-Best loss so far is now the GDN + TileLang + MuonEq-R run. KDA remains an important reference backend, but GDN stays the default because it is faster and currently gives the best overall frontier on this host.
+6. Current square-GDN quality-best: kept the same alternating hybrid layout and MuonEq-R recipe, but widened the GDN key state from `d_head/2` to `d_head`. That improved the best validation loss to `3.228005`, at the cost of higher runtime and memory.
+
+Best loss so far is now the square-GDN + TileLang + MuonEq-R run. The older param-matched GDN recipe remains the lighter-weight default when the extra square-head cost is not worthwhile. KDA remains an important reference backend, but GDN stays the default because it gives the best overall frontier on this host.
 
 ```
 ```

--- a/research/hybrid_attn/train.py
+++ b/research/hybrid_attn/train.py
@@ -99,6 +99,9 @@ parser.add_argument("--logit-cap", type=float, default=10.0,
                     help="Logit soft-capping value (0=disabled)")
 parser.add_argument("--gdn-layers", type=str, default="auto",
                     help="Comma-separated layer indices for GatedDeltaNet, or 'auto' for all-but-first-last-every-7th, or 'none'")
+parser.add_argument("--gdn-head-dim-mode", type=str, default="param-matched",
+                    choices=("param-matched", "square"),
+                    help="GDN key-head geometry: param-matched uses K=d_head/2, square uses K=d_head")
 parser.add_argument("--gdn-no-conv", action="store_true",
                     help="Disable GDN short convolutions and use the projection-only fast path")
 parser.add_argument("--gdn-use-recurrent", action="store_true",
@@ -312,6 +315,7 @@ class GPTConfig:
     window_pattern: str = WINDOW_PATTERN
     dropout: float = 0.0
     gdn_layers: list = None  # layer indices that use GatedDeltaNet (None = all softmax)
+    gdn_head_dim_mode: str = "param-matched"
     gdn_no_conv: bool = False
     gdn_use_recurrent: bool = False
     gdn_profile: bool = False
@@ -372,16 +376,16 @@ class GatedDeltaNetAttention(nn.Module):
     """Gated Delta Net linear attention with negative eigenvalues.
     Paper: https://arxiv.org/abs/2412.06464
     Uses Mamba2-style forget gate + delta rule with beta in [0,2].
-    Param-matched to standard attention: ~4*d^2 per layer.
+    Param-matched mode stays close to ~4*d^2 per layer.
     """
     def __init__(self, config, layer_idx):
         super().__init__()
         self.n_embd = config.n_embd
         self.num_heads = config.n_head
-        self.head_k_dim = config.n_embd // config.n_head // 2  # 64 for d=1792, h=14
-        self.head_v_dim = config.n_embd // config.n_head        # 128 for d=1792, h=14
-        self.key_dim = self.num_heads * self.head_k_dim          # 896
-        self.value_dim = self.num_heads * self.head_v_dim        # 1792
+        self.head_v_dim = config.n_embd // config.n_head
+        self.head_k_dim = self.head_v_dim if config.gdn_head_dim_mode == "square" else self.head_v_dim // 2
+        self.key_dim = self.num_heads * self.head_k_dim
+        self.value_dim = self.num_heads * self.head_v_dim
         self.layer_idx = layer_idx
         self.use_short_conv = not config.gdn_no_conv
         self.use_recurrent = config.gdn_use_recurrent
@@ -1362,6 +1366,7 @@ print0(f"  grad_clip={args.grad_clip}")
 print0(f"  muon_eq_r={args.muon_eq_r}")
 print0(f"  muon_ns_schedule={args.muon_ns_schedule}")
 print0(f"  linear_attn_type={args.linear_attn_type}")
+print0(f"  gdn_head_dim_mode={args.gdn_head_dim_mode}")
 print0(f"  gdn_no_conv={args.gdn_no_conv}, gdn_use_recurrent={args.gdn_use_recurrent}, gdn_profile={args.gdn_profile}")
 print0(f"-----------------------")
 
@@ -1369,6 +1374,8 @@ if args.gdn_profile:
     print0("GDN profiling enabled; running in eager mode to keep section timings meaningful")
 if args.gdn_use_recurrent:
     print0("Experimental recurrent GDN kernel requested; chunk-kernel fallback remains enabled")
+if args.gdn_head_dim_mode != "param-matched" and args.linear_attn_type != "gdn":
+    raise RuntimeError("--gdn-head-dim-mode only applies to --linear-attn-type gdn")
 if args.linear_attn_type == "kda" and args.gdn_use_recurrent:
     raise RuntimeError("--gdn-use-recurrent is only implemented for --linear-attn-type gdn")
 if args.linear_attn_type == "kda" and HEAD_DIM != 128:
@@ -1450,6 +1457,7 @@ config = GPTConfig(
     vocab_size=vocab_size,
     dropout=args.dropout,
     gdn_layers=gdn_layer_indices,
+    gdn_head_dim_mode=args.gdn_head_dim_mode,
     gdn_no_conv=args.gdn_no_conv,
     gdn_use_recurrent=args.gdn_use_recurrent,
     gdn_profile=args.gdn_profile,
@@ -1734,6 +1742,7 @@ if args.save_result and master_process:
         "total_training_time_min": total_training_time / 60,
         "total_wall_time_sec": time.time() - _script_start,
         "peak_memory_mib": peak_memory_mib,
+        "gdn_head_dim_mode": args.gdn_head_dim_mode,
         "gdn_no_conv": args.gdn_no_conv,
         "gdn_use_recurrent": args.gdn_use_recurrent,
         "gdn_profile": args.gdn_profile,


### PR DESCRIPTION


## New Val Loss

- Best val loss: `3.228005`
- Final val loss: `3.239774`
- Previous quality-best baseline for comparison: `3.230877 / 3.243014`

## Train Time

- Training time: `87.99` min

## What Changes

- Add `--gdn-head-dim-mode {param-matched,square}` to `research/hybrid_attn/train.py`.
- In GDN square mode, set `head_k_dim = head_v_dim` instead of `head_v_dim / 2`.
- Log and save `gdn_head_dim_mode` in the startup summary and result JSON.
- Update `research/hybrid_attn/README.md` with the new quality record and the matching square-GDN launch command.

## Why It Helps

- Square mode widens the GDN key state from `K=64` to `K=128` on the current `1792 / 14` setup.
- That gives each GDN head more recurrent state capacity and a less bottlenecked key/value geometry.
- In the full controlled run, that extra capacity improved the best validation loss from `3.230877` to `3.228005`, at the cost of higher runtime and memory.
