### PR TITLE
Fixing FA3 import in main, tiny and 2 hour track. Adding inline comment in readme.md for HF and wandb setup.

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,8 @@ For now the limited track lives in the root directory, the tiny track lives at [
 ## Running the current record 
 
 You can reproduce the limited-compute record by running the following commands: 
-```bash 
+```bash
+# Set HF_TOKEN and WANDB_API_KEY in your environment first
 git clone https://github.com/qlabs-eng/slowrun.git && cd slowrun
 pip install -r requirements.txt
 python prepare_data.py

--- a/tiny/train.py
+++ b/tiny/train.py
@@ -159,7 +159,6 @@ def resolve_run_dir(run_name):
 # =============================================================================
 # Flash Attention (FA3 on Hopper, SDPA fallback elsewhere)
 # =============================================================================
-
 def _load_fa3():
     if not torch.cuda.is_available():
         return None
@@ -169,8 +168,12 @@ def _load_fa3():
             return None
         os.environ["HF_HUB_DISABLE_PROGRESS_BARS"] = "1"
         from kernels import get_kernel
-        return get_kernel('varunneal/flash-attention-3').flash_attn_interface
-    except Exception:
+        return get_kernel('kernels-community/flash-attn3', version=1)
+    except ImportError:
+        print0("Warning: kernels package not found. Install with: pip install -U kernels")
+        return None
+    except Exception as e:
+        print0(f"Warning: Failed to load FA3 kernel: {e}")
         return None
 
 _fa3 = _load_fa3()

--- a/train.py
+++ b/train.py
@@ -198,8 +198,12 @@ def _load_fa3():
             return None
         os.environ["HF_HUB_DISABLE_PROGRESS_BARS"] = "1"
         from kernels import get_kernel
-        return get_kernel('varunneal/flash-attention-3').flash_attn_interface
-    except Exception:
+        return get_kernel('kernels-community/flash-attn3', version=1)
+    except ImportError:
+        print0("Warning: kernels package not found. Install with: pip install -U kernels")
+        return None
+    except Exception as e:
+        print0(f"Warning: Failed to load FA3 kernel: {e}")
         return None
 
 _fa3 = _load_fa3()

--- a/two_hour/train.py
+++ b/two_hour/train.py
@@ -227,6 +227,7 @@ def load_state_dict_into_model(model, state_dict):
 # Flash Attention (FA3 on Hopper)
 # =============================================================================
 
+
 def _load_fa3():
     if not torch.cuda.is_available():
         return None
@@ -236,8 +237,12 @@ def _load_fa3():
             return None
         os.environ["HF_HUB_DISABLE_PROGRESS_BARS"] = "1"
         from kernels import get_kernel
-        return get_kernel('varunneal/flash-attention-3').flash_attn_interface
-    except Exception:
+        return get_kernel('kernels-community/flash-attn3', version=1)
+    except ImportError:
+        print0("Warning: kernels package not found. Install with: pip install -U kernels")
+        return None
+    except Exception as e:
+        print0(f"Warning: Failed to load FA3 kernel: {e}")
         return None
 
 _fa3 = _load_fa3()


### PR DESCRIPTION
Switching to importing FA3 from https://huggingface.co/kernels-community/flash-attn3/ as the older method was not working. 
Added a one line comment prompting the user to set HF token and wandb API key in the "Running the current record" section for completeness. 