### PR TITLE
First-order meta-gradient every step: 3.183 val loss in 59.3m

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ The limited-compute track caps runs at a single 8xH100 node for at most 1 hour.
 18 | 3.211 | Add [MuonEq-R](https://arxiv.org/abs/2603.28254) | 04/17/26 | 59.4 mins | [Script](https://github.com/qlabs-eng/slowrun/blob/a2ed9f4530d2dbd80b8cc0b8775659b196053277/train.py) | [@clarkkev](https://github.com/clarkkev)
 19 | 3.204 | Add document-level shuffling | 04/24/26 | 59.0 mins | [Script](https://github.com/qlabs-eng/slowrun/blob/a4732774888d535f681295de4ef1c66a57a3cc60/train.py) | [@samacqua](https://x.com/Sam_Acqua)
 20 | 3.195 | Add weight decay schedule, adjust learning rate schedule | 04/26/26 | 59.0 mins | [Script](https://github.com/qlabs-eng/slowrun/blob/571b296eda47bdd291937d017ea49f23317088cb/train.py) | [@shmublu](https://x.com/ShmuelBerman)
+21 | 3.183 | First-order meta-gradient every step (split half-batches, temporary step on the Muon matrices); dropout 0.05, no stochastic depth | 09/05/26 | 59.3 mins | [Script](https://github.com/dangxingyu/slowrun/blob/ttt-every-step-1h/train.py) | [@dangxingyu](https://github.com/dangxingyu)
 
 
 ### Tiny Track (15 minutes)

--- a/README.md
+++ b/README.md
@@ -56,7 +56,6 @@ The limited-compute track caps runs at a single 8xH100 node for at most 1 hour.
 18 | 3.211 | Add [MuonEq-R](https://arxiv.org/abs/2603.28254) | 04/17/26 | 59.4 mins | [Script](https://github.com/qlabs-eng/slowrun/blob/a2ed9f4530d2dbd80b8cc0b8775659b196053277/train.py) | [@clarkkev](https://github.com/clarkkev)
 19 | 3.204 | Add document-level shuffling | 04/24/26 | 59.0 mins | [Script](https://github.com/qlabs-eng/slowrun/blob/a4732774888d535f681295de4ef1c66a57a3cc60/train.py) | [@samacqua](https://x.com/Sam_Acqua)
 20 | 3.195 | Add weight decay schedule, adjust learning rate schedule | 04/26/26 | 59.0 mins | [Script](https://github.com/qlabs-eng/slowrun/blob/571b296eda47bdd291937d017ea49f23317088cb/train.py) | [@shmublu](https://x.com/ShmuelBerman)
-21 | 3.183 | First-order meta-gradient every step (split half-batches, temporary step on the Muon matrices); dropout 0.05, no stochastic depth | 09/05/26 | 59.3 mins | [Script](https://github.com/dangxingyu/slowrun/blob/ttt-every-step-1h/train.py) | [@dangxingyu](https://github.com/dangxingyu)
 
 
 ### Tiny Track (15 minutes)

--- a/train.py
+++ b/train.py
@@ -92,13 +92,13 @@ parser.add_argument("--iha-lr", type=float, default=0.02,
                     help="LR for IHA mixing matrices")
 parser.add_argument("--no-doc-shuffle", action="store_true",
                     help="Disable per-epoch document reshuffling (still shuffles batch order)")
-# --- every-step training-time-testing episode (default for this entry; --ttt-every 0 --dropout 0.1 --stoch-depth 0.05 = entry 20) ---
+# --- every-step meta-gradient step (default for this entry; --mg-every 0 --dropout 0.1 --stoch-depth 0.05 = entry 20) ---
 parser.add_argument("--seed", type=int, default=42)
-parser.add_argument("--ttt-every", type=int, default=1, help="episode every N steps (1 = every step, the record; 0 = off = entry 20)")
-parser.add_argument("--ttt-step-norm", type=float, default=0.5, help="L2 norm of the temporary step on the plastic matrices")
-parser.add_argument("--ttt-step-schedule", type=str, default="lr", choices=["const", "lr"],
+parser.add_argument("--mg-every", type=int, default=1, help="meta-gradient step every N steps (1 = every step, the record; 0 = off = entry 20)")
+parser.add_argument("--mg-step-norm", type=float, default=0.5, help="L2 norm of the temporary step on the plastic matrices")
+parser.add_argument("--mg-step-schedule", type=str, default="lr", choices=["const", "lr"],
                     help="lr: scale the step norm by the warmdown learning-rate multiplier")
-parser.add_argument("--ttt-plastic", type=str, default="matrix_all", choices=["matrix_all", "mlp_all"])
+parser.add_argument("--mg-plastic", type=str, default="matrix_all", choices=["matrix_all", "mlp_all"])
 args = parser.parse_args()
 
 # Resolve output path
@@ -1069,10 +1069,10 @@ model = torch.compile(model, dynamic=False)
 # Optimizer
 optimizer = model.setup_optimizer()
 
-# ---- every-step training-time-testing episode ----
-TTT = args.ttt_every > 0
-ttt_params, ttt_owned = [], []   # plastic matrices; indices of the ones this rank owns in the Muon step
-if TTT:
+# ---- every-step meta-gradient step ----
+MG = args.mg_every > 0
+mg_params, mg_owned = [], []   # plastic matrices; indices of the ones this rank owns in the Muon step
+if MG:
     owned_ids = set()
     for g in optimizer.param_groups:
         if g["kind"] == "muon":   # Muon updates params[rank*chunk:(rank+1)*chunk] on this rank and all-gathers the rest
@@ -1080,27 +1080,27 @@ if TTT:
             owned_ids.update(id(p) for p in g["params"][ddp_rank * chunk:(ddp_rank + 1) * chunk])
     muon_ids = {id(p) for g in optimizer.param_groups if g["kind"] == "muon" for p in g["params"]}
     for name, p in orig_model.named_parameters():
-        if id(p) in muon_ids and (args.ttt_plastic == "matrix_all" or ".mlp." in name):
-            ttt_params.append(p)
+        if id(p) in muon_ids and (args.mg_plastic == "matrix_all" or ".mlp." in name):
+            mg_params.append(p)
             if id(p) in owned_ids:
-                ttt_owned.append(len(ttt_params) - 1)
-    print0(f"[ttt] every {args.ttt_every} steps, step norm {args.ttt_step_norm} ({args.ttt_step_schedule}), "
-           f"{len(ttt_params)} plastic matrices, {sum(p.numel() for p in ttt_params):,} parameters; "
-           f"rank {ddp_rank} restores {len(ttt_owned)} of them")
-ttt_owned_params = [ttt_params[i] for i in ttt_owned]
+                mg_owned.append(len(mg_params) - 1)
+    print0(f"[mg] every {args.mg_every} steps, step norm {args.mg_step_norm} ({args.mg_step_schedule}), "
+           f"{len(mg_params)} plastic matrices, {sum(p.numel() for p in mg_params):,} parameters; "
+           f"rank {ddp_rank} restores {len(mg_owned)} of them")
+mg_owned_params = [mg_params[i] for i in mg_owned]
 
 @torch.no_grad()
-def ttt_temporary_step(step):
+def mg_temporary_step(step):
     """theta_P <- theta_P - eta * g_P / ||g_P|| with g the gradient accumulated so far on this rank.
     Returns (scaled gradient of the owned matrices, alpha) so the caller can undo the step: the Muon
     step overwrites every matrix this rank does not own with the owner's all-gathered copy, so only
     the owned matrices need restoring."""
-    grads = [p.grad if p.grad is not None else torch.zeros_like(p) for p in ttt_params]
+    grads = [p.grad if p.grad is not None else torch.zeros_like(p) for p in mg_params]
     norm = torch.linalg.vector_norm(torch.stack(torch._foreach_norm(grads))).clamp_min(1e-12)
-    eta = args.ttt_step_norm * (get_lr_multiplier(step) if args.ttt_step_schedule == "lr" else 1.0)
+    eta = args.mg_step_norm * (get_lr_multiplier(step) if args.mg_step_schedule == "lr" else 1.0)
     alpha = -eta / float(norm)
-    kept = [grads[i].clone() for i in ttt_owned]
-    torch._foreach_add_(ttt_params, grads, alpha=alpha)
+    kept = [grads[i].clone() for i in mg_owned]
+    torch._foreach_add_(mg_params, grads, alpha=alpha)
     return kept, alpha
 
 # Dataloaders
@@ -1197,7 +1197,7 @@ while not args.eval_logit_avg and current_epoch <= args.num_epochs:
     # Training step
     synchronize()
     t0 = time.time()
-    if TTT and step % args.ttt_every == 0 and grad_accum_steps >= 2:
+    if MG and step % args.mg_every == 0 and grad_accum_steps >= 2:
         # split pairing: the first half of this step's micro-batches adapts, the second half is
         # evaluated at the adapted point; the optimizer receives the ordinary full-batch mean gradient
         half = grad_accum_steps // 2
@@ -1208,10 +1208,10 @@ while not args.eval_logit_avg and current_epoch <= args.num_epochs:
             (loss / grad_accum_steps).backward()
             x, y, epoch = next(train_loader)
             if micro_step == half - 1:
-                ttt_kept, ttt_alpha = ttt_temporary_step(step)
+                mg_kept, mg_alpha = mg_temporary_step(step)
         with torch.no_grad():
-            torch._foreach_add_(ttt_owned_params, ttt_kept, alpha=-ttt_alpha)   # restore the owned matrices
-        del ttt_kept
+            torch._foreach_add_(mg_owned_params, mg_kept, alpha=-mg_alpha)   # restore the owned matrices
+        del mg_kept
     else:
         for micro_step in range(grad_accum_steps):
             with autocast_ctx:

--- a/train.py
+++ b/train.py
@@ -56,7 +56,7 @@ parser.add_argument("--input_bin", type=str, default=None)
 parser.add_argument("--input_val_bin", type=str, default=None)
 parser.add_argument("--output_json", type=str, default=None)
 parser.add_argument("--wandb_group", type=str, default=None)
-parser.add_argument("--dropout", type=float, default=0.1)
+parser.add_argument("--dropout", type=float, default=0.05)   # 0.1 in entry 20
 parser.add_argument("--dupe-start-epoch", type=int, default=7,
                     help="Epoch to enable layer duplication")
 parser.add_argument("--dupe-layers-start", type=int, default=15,
@@ -80,7 +80,7 @@ parser.add_argument("--eval-logit-avg", action="store_true",
                     help="Skip training and only run logit-avg eval on saved checkpoints")
 parser.add_argument("--swa-last-epochs", type=int, default=3,
                     help="SWA: cosine-cycle LR in last N epochs for checkpoint diversity (0=off)")
-parser.add_argument("--stoch-depth", type=float, default=0.05,
+parser.add_argument("--stoch-depth", type=float, default=0.0,   # 0.05 in entry 20
                     help="Stochastic depth max drop rate (linear schedule, 0=off)")
 parser.add_argument("--mtp-weight", type=float, default=0.3,
                     help="Multi-token prediction weight (0=off)")
@@ -92,6 +92,13 @@ parser.add_argument("--iha-lr", type=float, default=0.02,
                     help="LR for IHA mixing matrices")
 parser.add_argument("--no-doc-shuffle", action="store_true",
                     help="Disable per-epoch document reshuffling (still shuffles batch order)")
+# --- every-step training-time-testing episode (default for this entry; --ttt-every 0 --dropout 0.1 --stoch-depth 0.05 = entry 20) ---
+parser.add_argument("--seed", type=int, default=42)
+parser.add_argument("--ttt-every", type=int, default=1, help="episode every N steps (1 = every step, the record; 0 = off = entry 20)")
+parser.add_argument("--ttt-step-norm", type=float, default=0.5, help="L2 norm of the temporary step on the plastic matrices")
+parser.add_argument("--ttt-step-schedule", type=str, default="lr", choices=["const", "lr"],
+                    help="lr: scale the step norm by the warmdown learning-rate multiplier")
+parser.add_argument("--ttt-plastic", type=str, default="matrix_all", choices=["matrix_all", "mlp_all"])
 args = parser.parse_args()
 
 # Resolve output path
@@ -947,12 +954,12 @@ def evaluate_bpb_logit_avg(eval_model, ckpt_paths, weights, steps):
 # Compute init
 ddp, ddp_rank, ddp_local_rank, ddp_world_size = get_dist_info()
 master_process = ddp_rank == 0
-torch.manual_seed(42)
+torch.manual_seed(args.seed)
 
 if ddp and torch.cuda.is_available():
     device = torch.device("cuda", ddp_local_rank)
     torch.cuda.set_device(device)
-    torch.cuda.manual_seed(42)
+    torch.cuda.manual_seed(args.seed)
     dist.init_process_group(backend="nccl", device_id=device)
     dist.barrier()
 else:
@@ -1062,6 +1069,40 @@ model = torch.compile(model, dynamic=False)
 # Optimizer
 optimizer = model.setup_optimizer()
 
+# ---- every-step training-time-testing episode ----
+TTT = args.ttt_every > 0
+ttt_params, ttt_owned = [], []   # plastic matrices; indices of the ones this rank owns in the Muon step
+if TTT:
+    owned_ids = set()
+    for g in optimizer.param_groups:
+        if g["kind"] == "muon":   # Muon updates params[rank*chunk:(rank+1)*chunk] on this rank and all-gathers the rest
+            chunk = (len(g["params"]) + ddp_world_size - 1) // ddp_world_size
+            owned_ids.update(id(p) for p in g["params"][ddp_rank * chunk:(ddp_rank + 1) * chunk])
+    muon_ids = {id(p) for g in optimizer.param_groups if g["kind"] == "muon" for p in g["params"]}
+    for name, p in orig_model.named_parameters():
+        if id(p) in muon_ids and (args.ttt_plastic == "matrix_all" or ".mlp." in name):
+            ttt_params.append(p)
+            if id(p) in owned_ids:
+                ttt_owned.append(len(ttt_params) - 1)
+    print0(f"[ttt] every {args.ttt_every} steps, step norm {args.ttt_step_norm} ({args.ttt_step_schedule}), "
+           f"{len(ttt_params)} plastic matrices, {sum(p.numel() for p in ttt_params):,} parameters; "
+           f"rank {ddp_rank} restores {len(ttt_owned)} of them")
+ttt_owned_params = [ttt_params[i] for i in ttt_owned]
+
+@torch.no_grad()
+def ttt_temporary_step(step):
+    """theta_P <- theta_P - eta * g_P / ||g_P|| with g the gradient accumulated so far on this rank.
+    Returns (scaled gradient of the owned matrices, alpha) so the caller can undo the step: the Muon
+    step overwrites every matrix this rank does not own with the owner's all-gathered copy, so only
+    the owned matrices need restoring."""
+    grads = [p.grad if p.grad is not None else torch.zeros_like(p) for p in ttt_params]
+    norm = torch.linalg.vector_norm(torch.stack(torch._foreach_norm(grads))).clamp_min(1e-12)
+    eta = args.ttt_step_norm * (get_lr_multiplier(step) if args.ttt_step_schedule == "lr" else 1.0)
+    alpha = -eta / float(norm)
+    kept = [grads[i].clone() for i in ttt_owned]
+    torch._foreach_add_(ttt_params, grads, alpha=alpha)
+    return kept, alpha
+
 # Dataloaders
 _train_path = args.input_bin if args.input_bin else os.path.join(DATA_DIR, "fineweb_train.pt")
 _val_path = args.input_val_bin if args.input_val_bin else os.path.join(DATA_DIR, "fineweb_val.pt")
@@ -1156,12 +1197,28 @@ while not args.eval_logit_avg and current_epoch <= args.num_epochs:
     # Training step
     synchronize()
     t0 = time.time()
-    for micro_step in range(grad_accum_steps):
-        with autocast_ctx:
-            loss, metrics = model(x, y)
-        train_loss = loss.detach()
-        (loss / grad_accum_steps).backward()
-        x, y, epoch = next(train_loader)
+    if TTT and step % args.ttt_every == 0 and grad_accum_steps >= 2:
+        # split pairing: the first half of this step's micro-batches adapts, the second half is
+        # evaluated at the adapted point; the optimizer receives the ordinary full-batch mean gradient
+        half = grad_accum_steps // 2
+        for micro_step in range(grad_accum_steps):
+            with autocast_ctx:
+                loss, metrics = model(x, y)
+            train_loss = loss.detach()
+            (loss / grad_accum_steps).backward()
+            x, y, epoch = next(train_loader)
+            if micro_step == half - 1:
+                ttt_kept, ttt_alpha = ttt_temporary_step(step)
+        with torch.no_grad():
+            torch._foreach_add_(ttt_owned_params, ttt_kept, alpha=-ttt_alpha)   # restore the owned matrices
+        del ttt_kept
+    else:
+        for micro_step in range(grad_accum_steps):
+            with autocast_ctx:
+                loss, metrics = model(x, y)
+            train_loss = loss.detach()
+            (loss / grad_accum_steps).backward()
+            x, y, epoch = next(train_loader)
 
     # Update optimizer
     lrm = get_lr_multiplier(step)


### PR DESCRIPTION
Each optimizer step splits its own batch in two halves. The gradient of the first half is taken at
the current weights, a temporary step of fixed L2 norm is applied along it on all Muon-managed
matrices, the gradient of the second half is taken at that adapted point, the temporary step is
undone, and the optimizer receives the mean of the two gradients. The second half's gradient at the
adapted point is a first-order meta-gradient: the first half is the adaptation batch, the second half
the evaluation batch. (The script's flags call the episode `ttt`, training-time testing.) Everything is rank-local, there is no extra communication, and the two
half-batches cost exactly what the eight micro-batches already cost; the episode's own work is about
12 ms of a 1.5-1.9 s step. Nothing else in the recipe's data, passes, optimizer, schedules, SWA, or
evaluation changes. Two recipe hyperparameters move with it and are the script's new defaults:
dropout 0.1 -> 0.05 and stochastic depth 0.05 -> 0 (the episode regularises on its own).

Per step (the script's defaults):

```
g   = 1/2 * mean-grad(theta; micro-batches 1-4)       # accumulated in .grad on this rank
d   = g|P / ||g|P||                                    # P = the 279 Muon matrices (1.26B params)
theta_P -= eta * d,  eta = 0.5 * m(t)                  # m(t): the recipe's warmdown LR multiplier
g  += 1/2 * mean-grad(theta; micro-batches 5-8)       # second half at the adapted point
theta_P += eta * d                                     # restore (fp32, to rounding; see below)
optimizer.step(g)                                      # g = 1/2 (grad_A + grad_Q): the usual full-batch mean
```

The restore covers only the matrices this rank owns in the Muon step; the optimizer's all-gather
overwrites the rest, so the restore is exact (two 60-step runs with full and owned restore end at the
same loss to 1e-6) and the extra memory is one eighth of the plastic gradients (0.6 GB).

Results on one 8xH100 80GB HBM3 node, 11 passes, val loss (training time):

| seed | baseline | this script |
| --- | --- | --- |
| 42 | 3.2005 (59.2 min) | 3.1814 (59.2 min) |
| 43 | 3.2013 (59.4 min) | 3.1830 (59.3 min) * |
| 44 | 3.2034 (58.5 min) | 3.1818 (59.3 min) |
| 45 | 3.2026 (58.7 min) | 3.1824 (59.0 min) |

\* the submitted run. Gain on the same seed: 0.019 / 0.018 / 0.022 / 0.020; fixed-seed run-to-run
noise is about 0.001. The seed-45 baseline is this script with `--ttt-every 0 --dropout 0.1
--stoch-depth 0.05`, which restores the baseline loop. Published record: 3.195 at 59.0 min; our
reproduction of the baseline on this hardware is 0.005-0.008 worse than the
published number.

The episode is a faster optimizer for most of training rather than a better end point: the per-pass
validation loss is 0.09 below the baseline after the first pass, 0.02-0.04 through the middle, and
meets it in the last two passes; the three-checkpoint average then gains more than the baseline's.
Only the every-step form does this (every 16, 8, or 4 steps gain 0.002-0.003, every 2 steps 0.005).
Two controls at the same step schedule: a random direction of the same norm gives the unchanged-script
loss (3.1998), the ascent direction is worse than it (3.2035); consecutive-batch pairing (adapt on
this batch, test on the next) gives 3.1948 in twice the time. Step norms 0.3-0.5 work and 1.0 hurts;
the split ratio of the two halves does not matter as long as the optimizer receives the plain
full-batch mean.

Timing: the same script's training time depends on the node. On the nodes we used, identical
runs span 58.8-59.8 minutes; one node is 3 percent slower per step and runs there exceed the cap by
about half a minute at the same loss, so only runs from normal-speed nodes are listed. Peak memory
51.7 GB per GPU (baseline: 51.0 GB).

Script: `train.py` on current `main` with the episode added (+67 / -10 lines). Defaults reproduce
this entry except the seed; `--ttt-every 0 --dropout 0.1 --stoch-depth 0.05` gives back the baseline
training loop (the upstream micro-batch loop is kept verbatim in the `else` branch). Reproduce:

```bash
torchrun --standalone --nproc_per_node=8 train.py --seed 43
# equivalent explicit flags: --ttt-every 1 --ttt-step-norm 0.5 --ttt-step-schedule lr --ttt-plastic matrix_all --dropout 0.05 --stoch-depth 0.0
```

Training logs of every run in the table: https://gist.github.com/dangxingyu/c1c6754312714772b2927b8c6ca0c874 (one `Result saved to <path>` line per log redacted).
