### PR TITLE
First-order meta-gradient every step on the MLP matrices: 3.295 val loss in 14.2m

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,6 @@ The tiny track caps runs at a single 8xH100 node for at most 15 minutes.
 12 | 3.324 | Add 2x recurrence | 06/07/26 | 14.9 mins | [Script](https://github.com/qlabs-eng/slowrun/blob/a2c443e18f99d0f6e35c6013c752e636fe402213/tiny/train.py) | [@neel04](https://x.com/awesome_ruler_)
 13 | 3.315 | Add fp8 MTP + full-layer XSA | 06/08/26 | 13.9 mins | [Script](https://github.com/qlabs-eng/slowrun/blob/9732ac294aba594a1fbb3aff1bb93cfdf2ce6788/tiny/train.py) | [@Mister-dev-oss](https://github.com/Mister-dev-oss)
 14 | 3.307 | Merge 2x recurrence with latest changes | 06/14/26 | 14.1 mins | [Script](https://github.com/qlabs-eng/slowrun/blob/d1fbdb76386347f1097ed051f4bebaef2c17758d/tiny/train.py) | [@neel04](https://x.com/awesome_ruler_)
-15 | 3.295 | First-order meta-gradient every step on the MLP matrices (split half-batches, temporary step of norm 0.5); precompile the half-batch shape | 09/05/26 | 14.2 mins | [Script](https://github.com/dangxingyu/slowrun/blob/ttt-every-step-tiny/tiny/train.py) | [@dangxingyu](https://github.com/dangxingyu)
 
 
 

--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ The tiny track caps runs at a single 8xH100 node for at most 15 minutes.
 12 | 3.324 | Add 2x recurrence | 06/07/26 | 14.9 mins | [Script](https://github.com/qlabs-eng/slowrun/blob/a2c443e18f99d0f6e35c6013c752e636fe402213/tiny/train.py) | [@neel04](https://x.com/awesome_ruler_)
 13 | 3.315 | Add fp8 MTP + full-layer XSA | 06/08/26 | 13.9 mins | [Script](https://github.com/qlabs-eng/slowrun/blob/9732ac294aba594a1fbb3aff1bb93cfdf2ce6788/tiny/train.py) | [@Mister-dev-oss](https://github.com/Mister-dev-oss)
 14 | 3.307 | Merge 2x recurrence with latest changes | 06/14/26 | 14.1 mins | [Script](https://github.com/qlabs-eng/slowrun/blob/d1fbdb76386347f1097ed051f4bebaef2c17758d/tiny/train.py) | [@neel04](https://x.com/awesome_ruler_)
+15 | 3.295 | First-order meta-gradient every step on the MLP matrices (split half-batches, temporary step of norm 0.5); precompile the half-batch shape | 09/05/26 | 14.2 mins | [Script](https://github.com/dangxingyu/slowrun/blob/ttt-every-step-tiny/tiny/train.py) | [@dangxingyu](https://github.com/dangxingyu)
 
 
 

--- a/tiny/train.py
+++ b/tiny/train.py
@@ -126,12 +126,12 @@ parser.add_argument("--mtp-predict", type=int, default=3,
                     help="MTP: number of future tokens predicted from each position (1 = plain next-token).")
 parser.add_argument("--mtp-anneal-frac", type=float, default=0.66,
                     help="Fraction of training over which the extra MTP heads decay to zero weight.")
-# --- every-step training-time-testing episode (default for this entry; --ttt-every 0 = entry 14) ---
+# --- every-step meta-gradient step (default for this entry; --mg-every 0 = entry 14) ---
 parser.add_argument("--seed", type=int, default=42)
-parser.add_argument("--ttt-every", type=int, default=1, help="episode every N steps (1 = every step, the record; 0 = off = entry 14)")
-parser.add_argument("--ttt-step-norm", type=float, default=0.5, help="L2 norm of the temporary step on the plastic matrices")
-parser.add_argument("--ttt-step-schedule", type=str, default="const", choices=["const", "lr"])
-parser.add_argument("--ttt-plastic", type=str, default="mlp_all", choices=["matrix_all", "mlp_all"])
+parser.add_argument("--mg-every", type=int, default=1, help="meta-gradient step every N steps (1 = every step, the record; 0 = off = entry 14)")
+parser.add_argument("--mg-step-norm", type=float, default=0.5, help="L2 norm of the temporary step on the plastic matrices")
+parser.add_argument("--mg-step-schedule", type=str, default="const", choices=["const", "lr"])
+parser.add_argument("--mg-plastic", type=str, default="mlp_all", choices=["matrix_all", "mlp_all"])
 args = parser.parse_args()
 
 # Resolve output path
@@ -1262,10 +1262,10 @@ model = torch.compile(model, dynamic=False)
 # Optimizer
 optimizer = model.setup_optimizer()
 
-# ---- every-step training-time-testing episode ----
-TTT = args.ttt_every > 0
-ttt_params, ttt_owned = [], []   # plastic matrices; indices of the ones this rank owns in the Muon step
-if TTT:
+# ---- every-step meta-gradient step ----
+MG = args.mg_every > 0
+mg_params, mg_owned = [], []   # plastic matrices; indices of the ones this rank owns in the Muon step
+if MG:
     owned_ids = set()
     for g in optimizer.param_groups:
         if g.get("kind") == "muon":   # Muon updates params[rank*chunk:(rank+1)*chunk] on this rank and all-gathers the rest
@@ -1273,27 +1273,27 @@ if TTT:
             owned_ids.update(id(p) for p in g["params"][ddp_rank * chunk:(ddp_rank + 1) * chunk])
     muon_ids = {id(p) for g in optimizer.param_groups if g.get("kind") == "muon" for p in g["params"]}
     for name, p in orig_model.named_parameters():
-        if id(p) in muon_ids and (args.ttt_plastic == "matrix_all" or ".mlp." in name):
-            ttt_params.append(p)
+        if id(p) in muon_ids and (args.mg_plastic == "matrix_all" or ".mlp." in name):
+            mg_params.append(p)
             if id(p) in owned_ids:
-                ttt_owned.append(len(ttt_params) - 1)
-    print0(f"[ttt] every {args.ttt_every} steps, step norm {args.ttt_step_norm} ({args.ttt_step_schedule}), "
-           f"{len(ttt_params)} plastic matrices, {sum(p.numel() for p in ttt_params):,} parameters; "
-           f"rank {ddp_rank} restores {len(ttt_owned)} of them")
-ttt_owned_params = [ttt_params[i] for i in ttt_owned]
+                mg_owned.append(len(mg_params) - 1)
+    print0(f"[mg] every {args.mg_every} steps, step norm {args.mg_step_norm} ({args.mg_step_schedule}), "
+           f"{len(mg_params)} plastic matrices, {sum(p.numel() for p in mg_params):,} parameters; "
+           f"rank {ddp_rank} restores {len(mg_owned)} of them")
+mg_owned_params = [mg_params[i] for i in mg_owned]
 
 @torch.no_grad()
-def ttt_temporary_step(step):
+def mg_temporary_step(step):
     """theta_P <- theta_P - eta * g_P / ||g_P|| with g the gradient of the first half-batch on this rank.
     Returns (scaled gradient of the owned matrices, alpha) so the caller can undo the step: the Muon
     step overwrites every matrix this rank does not own with the owner's all-gathered copy, so only
     the owned matrices need restoring."""
-    grads = [p.grad if p.grad is not None else torch.zeros_like(p) for p in ttt_params]
+    grads = [p.grad if p.grad is not None else torch.zeros_like(p) for p in mg_params]
     norm = torch.linalg.vector_norm(torch.stack(torch._foreach_norm(grads))).clamp_min(1e-12)
-    eta = args.ttt_step_norm * (get_lr_multiplier(step) if args.ttt_step_schedule == "lr" else 1.0)
+    eta = args.mg_step_norm * (get_lr_multiplier(step) if args.mg_step_schedule == "lr" else 1.0)
     alpha = -eta / float(norm)
-    kept = [grads[i].clone() for i in ttt_owned]
-    torch._foreach_add_(ttt_params, grads, alpha=alpha)
+    kept = [grads[i].clone() for i in mg_owned]
+    torch._foreach_add_(mg_params, grads, alpha=alpha)
     return kept, alpha
 
 # Dataloaders
@@ -1400,8 +1400,8 @@ precompile_iteration_stages(
     scheduled_iteration_counts,
     precompile_eval_iteration_counts,
 )
-if TTT:
-    # the episode runs two half-batch passes per step; warm that shape for every recurrence stage
+if MG:
+    # the step runs two half-batch passes per step; warm that shape for every recurrence stage
     # too, otherwise the 1x->2x transition recompiles inside the timed region
     _h = x.size(0) // 2
     precompile_iteration_stages(model, x[:_h], y[:_h], get_mtp_weights(step), scheduled_iteration_counts, ())
@@ -1453,20 +1453,20 @@ while current_epoch <= args.num_epochs:
     synchronize()
     t0 = time.time()
     mtp_w = get_mtp_weights(step)  # same weights across the grad-accum micro-steps
-    if TTT and step % args.ttt_every == 0 and grad_accum_steps == 1:
+    if MG and step % args.mg_every == 0 and grad_accum_steps == 1:
         # split pairing on the device batch: first half adapts, second half is evaluated at the
         # adapted point; the optimizer receives the ordinary full-batch mean gradient
         half = x.size(0) // 2
         with autocast_ctx:
             loss = model(x[:half], y[:half], num_iterations=active_num_iterations, mtp_weights=mtp_w).mean()
         (loss * 0.5).backward()
-        ttt_kept, ttt_alpha = ttt_temporary_step(step)
+        mg_kept, mg_alpha = mg_temporary_step(step)
         with autocast_ctx:
             loss_q = model(x[half:], y[half:], num_iterations=active_num_iterations, mtp_weights=mtp_w).mean()
         (loss_q * 0.5).backward()
         with torch.no_grad():
-            torch._foreach_add_(ttt_owned_params, ttt_kept, alpha=-ttt_alpha)   # restore the owned matrices
-        del ttt_kept
+            torch._foreach_add_(mg_owned_params, mg_kept, alpha=-mg_alpha)   # restore the owned matrices
+        del mg_kept
         train_loss = 0.5 * (loss.detach() + loss_q.detach())
         x, y, epoch = next(train_loader)
     else:

--- a/tiny/train.py
+++ b/tiny/train.py
@@ -126,6 +126,12 @@ parser.add_argument("--mtp-predict", type=int, default=3,
                     help="MTP: number of future tokens predicted from each position (1 = plain next-token).")
 parser.add_argument("--mtp-anneal-frac", type=float, default=0.66,
                     help="Fraction of training over which the extra MTP heads decay to zero weight.")
+# --- every-step training-time-testing episode (default for this entry; --ttt-every 0 = entry 14) ---
+parser.add_argument("--seed", type=int, default=42)
+parser.add_argument("--ttt-every", type=int, default=1, help="episode every N steps (1 = every step, the record; 0 = off = entry 14)")
+parser.add_argument("--ttt-step-norm", type=float, default=0.5, help="L2 norm of the temporary step on the plastic matrices")
+parser.add_argument("--ttt-step-schedule", type=str, default="const", choices=["const", "lr"])
+parser.add_argument("--ttt-plastic", type=str, default="mlp_all", choices=["matrix_all", "mlp_all"])
 args = parser.parse_args()
 
 # Resolve output path
@@ -1109,12 +1115,12 @@ def precompile_iteration_stages(model, x, y, mtp_weights, train_iteration_counts
 # Compute init
 ddp, ddp_rank, ddp_local_rank, ddp_world_size = get_dist_info()
 master_process = ddp_rank == 0
-torch.manual_seed(42)
+torch.manual_seed(args.seed)
 
 if ddp and torch.cuda.is_available():
     device = torch.device("cuda", ddp_local_rank)
     torch.cuda.set_device(device)
-    torch.cuda.manual_seed(42)
+    torch.cuda.manual_seed(args.seed)
     dist.init_process_group(backend="nccl", device_id=device)
     dist.barrier()
 else:
@@ -1256,6 +1262,40 @@ model = torch.compile(model, dynamic=False)
 # Optimizer
 optimizer = model.setup_optimizer()
 
+# ---- every-step training-time-testing episode ----
+TTT = args.ttt_every > 0
+ttt_params, ttt_owned = [], []   # plastic matrices; indices of the ones this rank owns in the Muon step
+if TTT:
+    owned_ids = set()
+    for g in optimizer.param_groups:
+        if g.get("kind") == "muon":   # Muon updates params[rank*chunk:(rank+1)*chunk] on this rank and all-gathers the rest
+            chunk = (len(g["params"]) + ddp_world_size - 1) // ddp_world_size
+            owned_ids.update(id(p) for p in g["params"][ddp_rank * chunk:(ddp_rank + 1) * chunk])
+    muon_ids = {id(p) for g in optimizer.param_groups if g.get("kind") == "muon" for p in g["params"]}
+    for name, p in orig_model.named_parameters():
+        if id(p) in muon_ids and (args.ttt_plastic == "matrix_all" or ".mlp." in name):
+            ttt_params.append(p)
+            if id(p) in owned_ids:
+                ttt_owned.append(len(ttt_params) - 1)
+    print0(f"[ttt] every {args.ttt_every} steps, step norm {args.ttt_step_norm} ({args.ttt_step_schedule}), "
+           f"{len(ttt_params)} plastic matrices, {sum(p.numel() for p in ttt_params):,} parameters; "
+           f"rank {ddp_rank} restores {len(ttt_owned)} of them")
+ttt_owned_params = [ttt_params[i] for i in ttt_owned]
+
+@torch.no_grad()
+def ttt_temporary_step(step):
+    """theta_P <- theta_P - eta * g_P / ||g_P|| with g the gradient of the first half-batch on this rank.
+    Returns (scaled gradient of the owned matrices, alpha) so the caller can undo the step: the Muon
+    step overwrites every matrix this rank does not own with the owner's all-gathered copy, so only
+    the owned matrices need restoring."""
+    grads = [p.grad if p.grad is not None else torch.zeros_like(p) for p in ttt_params]
+    norm = torch.linalg.vector_norm(torch.stack(torch._foreach_norm(grads))).clamp_min(1e-12)
+    eta = args.ttt_step_norm * (get_lr_multiplier(step) if args.ttt_step_schedule == "lr" else 1.0)
+    alpha = -eta / float(norm)
+    kept = [grads[i].clone() for i in ttt_owned]
+    torch._foreach_add_(ttt_params, grads, alpha=alpha)
+    return kept, alpha
+
 # Dataloaders
 _train_path = args.input_bin if args.input_bin else os.path.join(DATA_DIR, "fineweb_train.pt")
 _val_path = args.input_val_bin if args.input_val_bin else os.path.join(DATA_DIR, "fineweb_val.pt")
@@ -1360,6 +1400,11 @@ precompile_iteration_stages(
     scheduled_iteration_counts,
     precompile_eval_iteration_counts,
 )
+if TTT:
+    # the episode runs two half-batch passes per step; warm that shape for every recurrence stage
+    # too, otherwise the 1x->2x transition recompiles inside the timed region
+    _h = x.size(0) // 2
+    precompile_iteration_stages(model, x[:_h], y[:_h], get_mtp_weights(step), scheduled_iteration_counts, ())
 
 # Initial val evaluation
 model.eval()
@@ -1408,16 +1453,33 @@ while current_epoch <= args.num_epochs:
     synchronize()
     t0 = time.time()
     mtp_w = get_mtp_weights(step)  # same weights across the grad-accum micro-steps
-    for micro_step in range(grad_accum_steps):
+    if TTT and step % args.ttt_every == 0 and grad_accum_steps == 1:
+        # split pairing on the device batch: first half adapts, second half is evaluated at the
+        # adapted point; the optimizer receives the ordinary full-batch mean gradient
+        half = x.size(0) // 2
         with autocast_ctx:
-            # MTP path returns per-token weighted loss (B*T,); mean() reduces it as
-            # before. During the MTP phase this loss is the weighted multi-offset sum,
-            # so the logged value runs higher than the naive run until the extra
-            # offsets anneal to zero.
-            loss = model(x, y, num_iterations=active_num_iterations, mtp_weights=mtp_w).mean()
-        train_loss = loss.detach()
-        (loss / grad_accum_steps).backward()
+            loss = model(x[:half], y[:half], num_iterations=active_num_iterations, mtp_weights=mtp_w).mean()
+        (loss * 0.5).backward()
+        ttt_kept, ttt_alpha = ttt_temporary_step(step)
+        with autocast_ctx:
+            loss_q = model(x[half:], y[half:], num_iterations=active_num_iterations, mtp_weights=mtp_w).mean()
+        (loss_q * 0.5).backward()
+        with torch.no_grad():
+            torch._foreach_add_(ttt_owned_params, ttt_kept, alpha=-ttt_alpha)   # restore the owned matrices
+        del ttt_kept
+        train_loss = 0.5 * (loss.detach() + loss_q.detach())
         x, y, epoch = next(train_loader)
+    else:
+        for micro_step in range(grad_accum_steps):
+            with autocast_ctx:
+                # MTP path returns per-token weighted loss (B*T,); mean() reduces it as
+                # before. During the MTP phase this loss is the weighted multi-offset sum,
+                # so the logged value runs higher than the naive run until the extra
+                # offsets anneal to zero.
+                loss = model(x, y, num_iterations=active_num_iterations, mtp_weights=mtp_w).mean()
+            train_loss = loss.detach()
+            (loss / grad_accum_steps).backward()
+            x, y, epoch = next(train_loader)
 
     # Update optimizer
     lrm = get_lr_multiplier(step)


### PR DESCRIPTION
Each optimizer step splits its 32-sequence device batch in two halves of 16. The gradient of the first
half is taken at the current weights, a temporary step of fixed L2 norm is applied along it on the MLP
matrices, the gradient of the second half is taken at that adapted point, the temporary step is undone,
and the optimizer receives the mean of the two gradients: the ordinary full-batch mean. The second
half's gradient at the adapted point is a first-order meta-gradient (first half = adaptation batch,
second half = evaluation batch). Everything is rank-local; the two halves cost about what the single
32-sequence forward/backward cost. The recipe's dropout, weight decay, and schedules are unchanged
from the baseline (the current record). The same episode, on all Muon matrices, is submitted separately for the 1-hour track (https://github.com/qlabs-eng/slowrun/pull/98).

Per step (the script's defaults):

```
g   = 1/2 * mean-grad(theta; sequences 1-16)        # first half of the device batch, on this rank
d   = g|P / ||g|P||                                  # P = the 48 MLP matrices (138M params)
theta_P -= eta * d,  eta = 0.5                       # constant step norm
g  += 1/2 * mean-grad(theta; sequences 17-32)       # second half at the adapted point
theta_P += eta * d                                   # restore: only the matrices this rank owns in the Muon step (the all-gather overwrites the rest)
optimizer.step(g)
```

Results on one 8xH100 80GB HBM3 node, val loss (training time):

| seed | baseline | this script |
| --- | --- | --- |
| 42 | 3.3095 (13.8 min) | 3.2954 (14.2 min) * |
| 43 | 3.3046 (13.9 min) | 3.2958 (14.6 min) |
| 44 | 3.3070 (14.0 min) | 3.2939 (14.3 min) |
| 45 | 3.3101 (13.8 min) | 3.2984 (14.3 min) |

\* the submitted run. Gain on the same seed: 0.014 / 0.009 / 0.013 / 0.012; fixed-seed run-to-run
noise is about 0.001-0.002. Published record: 3.307 at 14.1 min.

Timing: the episode adds 8-14 ms to a 270 ms step. The tiny timer also counts recompiles, and the
recipe's 1x -> 2x recurrence transition (step 1996) recompiled the episode's half-batch shape in the
first version of this script, which cost 17-150 s. The submitted script precompiles the half-batch
shape for every recurrence stage before the timer starts; in every listed run step 1996 took the normal
2x-stage step time. Seed 43's 14.6 min is a node that is 3 percent slower per step.

Script: `tiny/train.py` (the baseline script) with the episode added (+72 / -10 lines). Defaults reproduce
this entry; `--ttt-every 0` gives back the baseline loop. Reproduce:

```bash
torchrun --standalone --nproc_per_node=8 tiny/train.py --seed 42
# equivalent explicit flags: --ttt-every 1 --ttt-step-norm 0.5 --ttt-step-schedule const --ttt-plastic mlp_all
```

Training logs of every run in the table: https://gist.github.com/dangxingyu/d45291f9ee1e3953879d5f65dbcd57a0 (one `Result saved to <path>` line per log redacted).
